### PR TITLE
FileResponse: send response either as attachment or inline

### DIFF
--- a/src/Application/Responses/FileResponse.php
+++ b/src/Application/Responses/FileResponse.php
@@ -33,13 +33,16 @@ class FileResponse extends Nette\Object implements Nette\Application\IResponse
 	/** @var bool */
 	public $resuming = TRUE;
 
+	/** @var bool */
+	private $forceDownload;
+
 
 	/**
 	 * @param  string  file path
 	 * @param  string  imposed file name
 	 * @param  string  MIME content type
 	 */
-	public function __construct($file, $name = NULL, $contentType = NULL)
+	public function __construct($file, $name = NULL, $contentType = NULL, $forceDownload = TRUE)
 	{
 		if (!is_file($file)) {
 			throw new Nette\Application\BadRequestException("File '$file' doesn't exist.");
@@ -48,6 +51,7 @@ class FileResponse extends Nette\Object implements Nette\Application\IResponse
 		$this->file = $file;
 		$this->name = $name ? $name : basename($file);
 		$this->contentType = $contentType ? $contentType : 'application/octet-stream';
+		$this->forceDownload = $forceDownload;
 	}
 
 
@@ -88,7 +92,8 @@ class FileResponse extends Nette\Object implements Nette\Application\IResponse
 	public function send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse)
 	{
 		$httpResponse->setContentType($this->contentType);
-		$httpResponse->setHeader('Content-Disposition', 'attachment; filename="' . $this->name . '"');
+		$httpResponse->setHeader('Content-Disposition',
+			($this->forceDownload ? 'attachment' : 'inline') . '; filename="' . $this->name . '"');
 
 		$filesize = $length = filesize($this->file);
 		$handle = fopen($this->file, 'r');

--- a/tests/Application/FileResponse.contentDisposition.phpt
+++ b/tests/Application/FileResponse.contentDisposition.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Nette\Application\Responses\FileResponse.
+ */
+
+use Nette\Application\Responses\FileResponse,
+	Nette\Http,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function() {
+	$file = __FILE__;
+	$fileResponse = new FileResponse($file);
+	$origData = file_get_contents($file);
+
+	$fileInfo = pathinfo($file);
+	$fileName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
+
+	ob_start();
+	$fileResponse->send(new Http\Request(new Http\UrlScript), $response = new Http\Response);
+
+	Assert::same( $origData, ob_get_clean() );
+	Assert::same( 'attachment; filename="' . $fileName . '"', $response->getHeader('Content-Disposition') );
+});
+
+
+test(function() {
+	$file = __FILE__;
+	$fileResponse = new FileResponse($file, NULL, NULL, FALSE);
+	$origData = file_get_contents($file);
+
+	$fileInfo = pathinfo($file);
+	$fileName = $fileInfo['filename'] . '.' . $fileInfo['extension'];
+
+	ob_start();
+	$fileResponse->send(new Http\Request(new Http\UrlScript), $response = new Http\Response);
+
+	Assert::same( $origData, ob_get_clean() );
+	Assert::same('inline; filename="' . $fileName . '"', $response->getHeader('Content-Disposition'));
+});


### PR DESCRIPTION
This pull requests allows files in response being sent directly into browser instead of forcing them to be downloaded - this is especially helpful when there is a need to show e.g. pdf files directly in the browser window. See related issue https://github.com/nette/nette/issues/1410.

As proposed in the contribution guide http://nette.org/en/contributing, I am adding following information:
- feature
- issues - #1410
- documentation - not needed
- BC break - no

I am really a newbie. I will appreciate if you provide me with some explaining comments in case you find this pull request as not acceptable. Thanks a lot!
