### PR TITLE
Route: Fixed handling of object parameters

### DIFF
--- a/src/Application/Routers/IObjectParameter.php
+++ b/src/Application/Routers/IObjectParameter.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Application\Routers;
+
+
+interface IObjectParameter
+{
+
+	/**
+	 * @return string representation of the parameter
+	 */
+	function __toString();
+
+}

--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -338,6 +338,12 @@ class Route extends Nette\Object implements Application\IRouter
 			}
 		}
 
+		array_walk_recursive($params, function (&$value) {
+			if ($value instanceof IObjectParameter) {
+				$value = (string) $value;
+			}
+		});
+
 		// compositing path
 		$sequence = $this->sequence;
 		$brackets = array();

--- a/tests/Application.Routers/Route.objectParameter.phpt
+++ b/tests/Application.Routers/Route.objectParameter.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test: Nette\Application\Routers\Route with object parameter
+ */
+
+use Nette\Application\Routers\IObjectParameter,
+	Nette\Application\Routers\Route,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Route.inc';
+
+
+class ObjectParameter implements IObjectParameter
+{
+	public function __toString()
+	{
+		return 'value';
+	}
+}
+
+$route = new Route('', array(
+	'presenter' => 'Presenter',
+));
+
+$params = array(
+	'entity' => new ObjectParameter(),
+	'array' => array(
+		new ObjectParameter(),
+	),
+);
+
+Assert::same('http://example.com/?entity=value&array%5B0%5D=value', testRouteOut($route, 'Presenter', $params));


### PR DESCRIPTION
Sometimes I use objects as parameters. A nice way to deal with them is to put them into another object using this class: https://gist.github.com/enumag/1f98ce3beffa2490c6ca.

Using this the object will be converted to it's identifier using the __toString method unless I do something else with it in the FILTER_OUT function. First way is useful in AdminModule because I don't care about pretty urls there. Second way is handy for FrontModule because I can slugify the object in FILTER_OUT.

This works fine if the parameter is mentioned in the route string directly. If it isn't it should appear in the query string - and this is the problem. The parameter disappears instead because the `http_build_query` function ignores objects completely (even if they have a __toString method declared).