### PR TITLE
Fixed error when using different implementation of IResponse

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -163,7 +163,7 @@ class Application extends Nette\Object
 	 */
 	public function processException(\Exception $e)
 	{
-		if (!$e instanceof BadRequestException) {
+		if (!$e instanceof BadRequestException && $this->httpResponse instanceof Nette\Http\Response) {
 			$this->httpResponse->warnOnBuffer = FALSE;
 		}
 		if (!$this->httpResponse->isSent()) {


### PR DESCRIPTION
Fixed error during exception handling when using different implementation of IResponse.

In process excpetion code access property warnOnBuffer which is not part of IResponse interface but only of it's specific implementation. Resolved by adding check for type.
