### PR TITLE
Changed $container to protected

### DIFF
--- a/src/Application/PresenterFactory.php
+++ b/src/Application/PresenterFactory.php
@@ -30,7 +30,7 @@ class PresenterFactory extends Nette\Object implements IPresenterFactory
 	private $cache = array();
 
 	/** @var Nette\DI\Container */
-	private $container;
+	protected $container;
 
 
 	public function __construct(Nette\DI\Container $container)


### PR DESCRIPTION
I would like to be able to override PresenterFactory's createPresenter(), but the private $container made it quite difficult..
