### PR TITLE
Router: optimized for a single immutable $refUrl instance

### DIFF
--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -108,6 +108,12 @@ class Route extends Nette\Object implements Application\IRouter
 	/** @var int */
 	private $flags;
 
+	/** @var Nette\Http\Url */
+	private $lastRefUrl;
+
+	/** @var string */
+	private $lastBaseUrl;
+
 
 	/**
 	 * @param  string  URL mask, e.g. '<presenter>/<action>/<id \d{1,3}>'
@@ -388,12 +394,14 @@ class Route extends Nette\Object implements Application\IRouter
 		} while (TRUE);
 
 
-		// absolutize path
-		if ($this->type === self::RELATIVE) {
-			$url = '//' . $refUrl->getAuthority() . $refUrl->getBasePath() . $url;
-
-		} elseif ($this->type === self::PATH) {
-			$url = '//' . $refUrl->getAuthority() . $url;
+		if ($this->type !== self::HOST) {
+			if ($this->lastRefUrl !== $refUrl) {
+				$scheme = ($this->flags & self::SECURED ? 'https://' : 'http://');
+				$basePath = ($this->type === self::RELATIVE ? $refUrl->getBasePath() : '');
+				$this->lastBaseUrl = $scheme . $refUrl->getAuthority() . $basePath;
+				$this->lastRefUrl = $refUrl;
+			}
+			$url = $this->lastBaseUrl . $url;
 
 		} else {
 			$host = $refUrl->getHost();
@@ -403,13 +411,12 @@ class Route extends Nette\Object implements Application\IRouter
 				'%tld%' => $host[0],
 				'%domain%' => isset($host[1]) ? "$host[1].$host[0]" : $host[0],
 			));
+			$url = ($this->flags & self::SECURED ? 'https:' : 'http:') . $url;
 		}
 
-		if (strpos($url, '//', 2) !== FALSE) {
+		if (strpos($url, '//', 7) !== FALSE) {
 			return NULL;
 		}
-
-		$url = ($this->flags & self::SECURED ? 'https:' : 'http:') . $url;
 
 		// build query string
 		if ($this->xlat) {


### PR DESCRIPTION
This makes it about 40 % faster with the following benchmark. However it relies on `$refUrl` being immutable.

```php
$appRequest = new AppRequest('Admin', 'GET', ['action' => 'default']);
$refUrl = new UrlScript('http://localhost/');

$time = -microtime(true);
$routerB = new RouteList();
$routerB[] = new Route('', 'Homepage:default');
$routerB[] = new Route('sign-in', 'Auth:signIn');
$routerB[] = new Route('sign-out', 'Auth:signOut');
$routerB[] = new Route('sign-up', 'Auth:signUp');
$routerB[] = new Route('sign-up-confirm', 'Auth:signUpConfirm');
$routerB[] = new Route('forgotten-pass', 'Auth:forgottenPassword');
$routerB[] = new Route('view', 'Product:view');
$routerB[] = new Route('manage', 'Product:manage');
$routerB[] = new Route('dashboard', 'Dashboard:default');
$routerB[] = new Route('admin', 'Admin:default');

for ($i = 0; $i < 10000; $i++) {
	$routerB->constructUrl($appRequest, $refUrl);
	// $routerB->match($httpRequest);
}
$time += microtime(true);

echo round($time * 1000, 2) . " ms\n";
```