### PR TITLE
LatteMacros: snippet rendering support for in template defined variables

### DIFF
--- a/src/Bridges/ApplicationLatte/UIMacros.php
+++ b/src/Bridges/ApplicationLatte/UIMacros.php
@@ -50,7 +50,7 @@ class UIMacros extends Latte\Macros\MacroSet
 		$prolog = '
 // snippets support
 if (empty($_l->extends) && !empty($_control->snippetMode)) {
-	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, get_defined_vars());
+	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, $template);
 }';
 		return array($prolog, '');
 	}
@@ -108,7 +108,7 @@ if (empty($_l->extends) && !empty($_control->snippetMode)) {
 	/********************* run-time helpers ****************d*g**/
 
 
-	public static function renderSnippets(Nette\Application\UI\Control $control, \stdClass $local, array $params)
+	public static function renderSnippets(Nette\Application\UI\Control $control, \stdClass $local, Latte\Template $template)
 	{
 		$control->snippetMode = FALSE;
 		$payload = $control->getPresenter()->getPayload();
@@ -119,7 +119,7 @@ if (empty($_l->extends) && !empty($_control->snippetMode)) {
 				}
 				ob_start();
 				$function = reset($function);
-				$snippets = $function($local, $params + array('_snippetMode' => TRUE));
+				$snippets = $function($local, $template->getParameters() + array('_snippetMode' => TRUE));
 				$payload->snippets[$id = $control->getSnippetId(substr($name, 1))] = ob_get_clean();
 				if ($snippets !== NULL) { // pass FALSE from snippetArea
 					if ($snippets) {

--- a/tests/Application.Latte/UIMacros.snippet4.phpt
+++ b/tests/Application.Latte/UIMacros.snippet4.phpt
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Test: snippets.
+ */
+
+use Nette\Bridges\ApplicationLatte\UIMacros,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class MockControl
+{
+	function __call($name, $args)
+	{
+	}
+}
+
+
+$latte = new Latte\Engine;
+UIMacros::install($latte->getCompiler());
+$latte->setLoader(new Latte\Loaders\StringLoader);
+
+Assert::match('<div id=""><em>test</em></div>'
+, $latte->renderToString('{snippetArea defaults}
+{if isset($template->testTpl) === FALSE}
+    {?$template->testTpl = \'<em>{:test}</em>\'}
+{/if}
+{/snippetArea}
+{snippet test}{=strtr($testTpl, array(\'{:test}\' => $test))|noescape}{/snippet}'
+, array('_control' => new MockControl,'test' => 'test')));

--- a/tests/Application.Latte/expected/UIMacros.dynamicsnippets.alt.phtml
+++ b/tests/Application.Latte/expected/UIMacros.dynamicsnippets.alt.phtml
@@ -43,7 +43,7 @@ if ($_l->extends) { ob_start();}
 
 // snippets support
 if (empty($_l->extends) && !empty($_control->snippetMode)) {
-	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, get_defined_vars());
+	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, $template);
 }
 
 //

--- a/tests/Application.Latte/expected/UIMacros.dynamicsnippets.phtml
+++ b/tests/Application.Latte/expected/UIMacros.dynamicsnippets.phtml
@@ -33,7 +33,7 @@ if ($_l->extends) { ob_start();}
 
 // snippets support
 if (empty($_l->extends) && !empty($_control->snippetMode)) {
-	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, get_defined_vars());
+	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, $template);
 }
 
 //

--- a/tests/Application.Latte/expected/UIMacros.snippet.alt.phtml
+++ b/tests/Application.Latte/expected/UIMacros.snippet.alt.phtml
@@ -40,7 +40,7 @@ if ($_l->extends) { ob_start();}
 
 // snippets support
 if (empty($_l->extends) && !empty($_control->snippetMode)) {
-	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, get_defined_vars());
+	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, $template);
 }
 
 //

--- a/tests/Application.Latte/expected/UIMacros.snippet.phtml
+++ b/tests/Application.Latte/expected/UIMacros.snippet.phtml
@@ -40,7 +40,7 @@ if (!function_exists($_b->blocks['_title2'][] = '_%[a-z0-9]+%__title2')) { funct
 //
 // end of blocks
 %A%
-	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, get_defined_vars());
+	return Nette\Bridges\ApplicationLatte\UIMacros::renderSnippets($_control, $_b, $template);
 %A%
 <div id="<?php echo $_control->getSnippetId('') ?>"><?php call_user_func(reset($_b->blocks['_']), $_b, $template->getParameters()) ?>
 </div>


### PR DESCRIPTION
Currently you can access `$template->getParameters()` defined in presenter/control in the snippet directly.

For example, if the `$template->getParameters()` contain `array('test' => 'value')`, you can access this variable in snippet directly:
```latte 
{snippet test}
    {dump $test}
{/snippet}
```

`$template` available in the latte is an object of `Latte\Template`, that is used to render current template. So when you set additional variable in this object, you can access this variable elsewhere in the same template and also in the snippets.

So when you have following code, everything work well.
```latte
{var $template->another_test = 'another value'}
{snippet test}
    {dump $template->another_test}
{/snippet}
```

But all parameters from `$template->getParameters()` can be accessible directly,
```latte
{var $template->another_test = 'another value'}
{snippet test}
    {dump $another_test}
{/snippet}
```
but except the in template defined.

This pull-request allow to define "in template global variable", than can be accessible directly in snippets like in the last example.

Also it resolve #46