### PR TITLE
Fixed routing debugger

### DIFF
--- a/src/Bridges/ApplicationDI/RoutingExtension.php
+++ b/src/Bridges/ApplicationDI/RoutingExtension.php
@@ -46,14 +46,21 @@ class RoutingExtension extends Nette\DI\CompilerExtension
 			$router->addSetup('$service[] = new Nette\Application\Routers\Route(?, ?);', array($mask, $action));
 		}
 
-		if ($this->debugMode && $config['debugger'] && $container->hasDefinition('application')) {
-			$container->getDefinition('application')->addSetup('@Tracy\Bar::addPanel', array(
-				new Nette\DI\Statement('Nette\Bridges\ApplicationTracy\RoutingPanel')
-			));
-		}
-
 		if ($this->name === 'routing') {
 			$container->addAlias('router', $this->prefix('router'));
+		}
+	}
+
+
+	public function beforeCompile()
+	{
+		$config = $this->validateConfig($this->defaults);
+		$container = $this->getContainerBuilder();
+
+		if ($this->debugMode && $config['debugger'] && $application = $container->getByType('Nette\Application\Application')) {
+			$container->getDefinition($application)->addSetup('@Tracy\Bar::addPanel', array(
+				new Nette\DI\Statement('Nette\Bridges\ApplicationTracy\RoutingPanel')
+			));
 		}
 	}
 


### PR DESCRIPTION
It's better for the future to not rely on the application alias. Also it's better to use `ContainerBuilder::getByType()` to find the service because the name of ApplicationExtension can vary as well. Of course `ContainerBuilder::getByType()` doesn't work in loadConfiguration, hence I moved the code to beforeCompile.