### PR TITLE
Route: Added getMetadata method [closes #19]

### DIFF
--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -667,6 +667,16 @@ class Route extends Nette\Object implements Application\IRouter
 	}
 
 
+	/**
+	 * Returns internal metadata.
+	 * @return array
+	 */
+	public function getMetadata()
+	{
+		return $this->metadata;
+	}
+
+
 	/********************* Utilities ****************d*g**/
 
 


### PR DESCRIPTION
The solution is a bit tricky (see below) but with the getMetadata method I indeed can solve #19.

```php
use Nette\Application\Routers\Route as BaseRoute;

class Route extends BaseRoute
{

	public function __construct($mask, $metadata = array(), $flags = 0)
	{
		$filter = function (array $parameters) {
			$metadata = $this->getMetadata();
			foreach ($parameters as $key => & $value) {
				if ($value instanceof IObjectParameter && !isset($metadata[$key][self::FILTER_OUT])) {
					$value = $value->__toString();
				}
			}
			return $parameters;
		};

		if (isset($metadata[NULL][self::FILTER_OUT])) {
			$custom = $metadata[NULL][self::FILTER_OUT];
			$metadata[NULL][self::FILTER_OUT] = function (array $parameters) use ($custom, $filter) {
				$parameters = call_user_func($custom, $parameters);
				if (!is_array($parameters)) {
					return $parameters;
				}
				return call_user_func($filter, $parameters);
			};
		} else {
			$metadata[NULL][self::FILTER_OUT] = $filter;
		}
		parent::__construct($mask, $metadata, $flags);
	}

}
```