### PR TITLE
Added third option to Application::$catchExceptions

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -90,7 +90,9 @@ class Application extends Nette\Object
 
 		} catch (\Exception $e) {
 			$this->onError($this, $e);
-			if ($this->catchExceptions && $this->errorPresenter) {
+
+			// if catchExceptions is NULL, catch only BadRequestException
+			if (($this->catchExceptions || ($this->catchExceptions === NULL && $e instanceof BadRequestException)) && $this->errorPresenter) {
 				try {
 					$this->processException($e);
 					$this->onShutdown($this, $e);

--- a/src/Bridges/ApplicationDI/ApplicationExtension.php
+++ b/src/Bridges/ApplicationDI/ApplicationExtension.php
@@ -21,7 +21,7 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 	public $defaults = array(
 		'debugger' => TRUE,
 		'errorPresenter' => 'Nette:Error',
-		'catchExceptions' => NULL,
+		'catchExceptions' => NULL, // true|false|smart
 		'mapping' => NULL,
 		'scanDirs' => array(),
 		'scanComposer' => NULL,
@@ -49,7 +49,7 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 
 		$application = $container->addDefinition($this->prefix('application'))
 			->setClass('Nette\Application\Application')
-			->addSetup('$catchExceptions', array($config['catchExceptions']))
+			->addSetup('$catchExceptions', array($config['catchExceptions'] === 'smart' ? NULL : $config['catchExceptions']))
 			->addSetup('$errorPresenter', array($config['errorPresenter']));
 
 		if ($config['debugger']) {


### PR DESCRIPTION
I use a bunch of services to check whether the application is in state to run the request, if the use has privileges and so on. However these services are not supposed to handle the error correctly with a flashmessage and redirect, they only throw an exception (some specific descendant of BadRequestException).

I handle these exceptions in ErrorPresenter which works fine but I have some troubles with this in debug mode - I don't want to see these exceptions because they are kind of expected and I want to see if the ErrorPresenter handles them correctly. Therefore in debug mode I want to catch BadRequestException.

I consider this approach to be far better then the usual. When writing the application I don't repeat the flash messages and redirects everywhere (it get's even worse if I need to translate them - I need to inject the translator). Instead I just throw an exception and later add a line or two to ErrorPresenter. Presenters and controls are much cleaner because they focus on what they are supposed to do and don't have to deal with errors at all.

What do you think about this solution? I use it for about year or so and am really satisfied with it.
