### PR TITLE
PresenterFactory as callback & changed invalid link handling [WIP]

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -34,9 +34,10 @@ use Nette,
 abstract class Presenter extends Control implements Application\IPresenter
 {
 	/** bad link handling {@link Presenter::$invalidLinkMode} */
-	const INVALID_LINK_SILENT = 1,
-		INVALID_LINK_WARNING = 2,
-		INVALID_LINK_EXCEPTION = 3;
+	const INVALID_LINK_SILENT = 0,
+		INVALID_LINK_WARNING = 1,
+		INVALID_LINK_EXCEPTION = 2,
+		INVALID_LINK_TEXTUAL = 4;
 
 	/** @internal special parameter key */
 	const SIGNAL_KEY = 'do',
@@ -1060,15 +1061,14 @@ abstract class Presenter extends Control implements Application\IPresenter
 	 */
 	protected function handleInvalidLink(InvalidLinkException $e)
 	{
-		if ($this->invalidLinkMode === self::INVALID_LINK_SILENT) {
-			return '#';
-
-		} elseif ($this->invalidLinkMode === self::INVALID_LINK_WARNING) {
-			return '#error: ' . $e->getMessage();
-
-		} else { // self::INVALID_LINK_EXCEPTION
+		if ($this->invalidLinkMode & self::INVALID_LINK_EXCEPTION) {
 			throw $e;
+		} elseif ($this->invalidLinkMode & self::INVALID_LINK_WARNING) {
+			trigger_error('Invalid link: ' . $e->getMessage(), E_USER_WARNING);
 		}
+		return $this->invalidLinkMode & self::INVALID_LINK_TEXTUAL
+			? '#error: ' . $e->getMessage()
+			: '#';
 	}
 
 

--- a/src/Bridges/ApplicationDI/ApplicationExtension.php
+++ b/src/Bridges/ApplicationDI/ApplicationExtension.php
@@ -56,10 +56,13 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 			$application->addSetup('Nette\Bridges\ApplicationTracy\RoutingPanel::initializePanel');
 		}
 
-		$touchToRebuild = $this->debugMode && $config['scanDirs'] ? reset($config['scanDirs']) : NULL;
+		$touch = $this->debugMode && $config['scanDirs'] ? reset($config['scanDirs']) : NULL; // dir added as dependency
+		$invalidLinkMode = $this->debugMode ? UI\Presenter::INVALID_LINK_WARNING : UI\Presenter::INVALID_LINK_SILENT;
 		$presenterFactory = $container->addDefinition($this->prefix('presenterFactory'))
 			->setClass('Nette\Application\IPresenterFactory')
-			->setFactory('Nette\Application\PresenterFactory', array(1 => $touchToRebuild));
+			->setFactory('Nette\Application\PresenterFactory', array(new Nette\DI\Statement(
+				'Nette\Bridges\ApplicationDI\PresenterFactoryCallback', array(1 => $invalidLinkMode, $touch)
+			)));
 
 		if ($config['mapping']) {
 			$presenterFactory->addSetup('setMapping', array($config['mapping']));

--- a/src/Bridges/ApplicationDI/ApplicationExtension.php
+++ b/src/Bridges/ApplicationDI/ApplicationExtension.php
@@ -26,10 +26,14 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 		'scanDirs' => array(),
 		'scanComposer' => NULL,
 		'scanFilter' => 'Presenter',
+		'silentLinks' => FALSE,
 	);
 
 	/** @var bool */
 	private $debugMode;
+
+	/** @var int */
+	private $invalidLinkMode;
 
 
 	public function __construct($debugMode = FALSE, array $scanDirs = NULL)
@@ -47,6 +51,10 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 		$container = $this->getContainerBuilder();
 		$container->addExcludedClasses(array('Nette\Application\UI\Control'));
 
+		$this->invalidLinkMode = $this->debugMode
+			? UI\Presenter::INVALID_LINK_TEXTUAL | ($config['silentLinks'] ? 0 : UI\Presenter::INVALID_LINK_WARNING)
+			: UI\Presenter::INVALID_LINK_WARNING;
+
 		$application = $container->addDefinition($this->prefix('application'))
 			->setClass('Nette\Application\Application')
 			->addSetup('$catchExceptions', array($config['catchExceptions']))
@@ -57,11 +65,10 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 		}
 
 		$touch = $this->debugMode && $config['scanDirs'] ? reset($config['scanDirs']) : NULL; // dir added as dependency
-		$invalidLinkMode = $this->debugMode ? UI\Presenter::INVALID_LINK_WARNING : UI\Presenter::INVALID_LINK_SILENT;
 		$presenterFactory = $container->addDefinition($this->prefix('presenterFactory'))
 			->setClass('Nette\Application\IPresenterFactory')
 			->setFactory('Nette\Application\PresenterFactory', array(new Nette\DI\Statement(
-				'Nette\Bridges\ApplicationDI\PresenterFactoryCallback', array(1 => $invalidLinkMode, $touch)
+				'Nette\Bridges\ApplicationDI\PresenterFactoryCallback', array(1 => $this->invalidLinkMode, $touch)
 			)));
 
 		if ($config['mapping']) {
@@ -99,9 +106,7 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 		foreach ($all as $def) {
 			$def->setInject(TRUE)->setAutowired(FALSE)->addTag('nette.presenter', $def->getClass());
 			if (is_subclass_of($def->getClass(), 'Nette\Application\UI\Presenter')) {
-				$def->addSetup('$invalidLinkMode', array(
-					$this->debugMode ? UI\Presenter::INVALID_LINK_WARNING : UI\Presenter::INVALID_LINK_SILENT
-				));
+				$def->addSetup('$invalidLinkMode', array($this->invalidLinkMode));
 			}
 		}
 	}

--- a/src/Bridges/ApplicationDI/PresenterFactoryCallback.php
+++ b/src/Bridges/ApplicationDI/PresenterFactoryCallback.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Bridges\ApplicationDI;
+
+use Nette;
+
+
+/**
+ * PresenterFactory callback.
+ * @internal
+ */
+class PresenterFactoryCallback
+{
+	/** @var Nette\DI\Container */
+	private $container;
+
+	/** @var int */
+	private $invalidLinkMode;
+
+	/** @var string|NULL */
+	private $touchToRefresh;
+
+
+	public function __construct(Nette\DI\Container $container, $invalidLinkMode, $touchToRefresh)
+	{
+		$this->container = $container;
+		$this->invalidLinkMode = $invalidLinkMode;
+		$this->touchToRefresh = $touchToRefresh;
+	}
+
+
+	/**
+	 * @return Nette\Application\IPresenter
+	 */
+	public function __invoke($class)
+	{
+		$services = array_keys($this->container->findByTag('nette.presenter'), $class);
+		if (count($services) > 1) {
+			throw new Nette\Application\InvalidPresenterException("Multiple services of type $class found: " . implode(', ', $services) . '.');
+
+		} elseif (!$services) {
+			if ($this->touchToRefresh) {
+				touch($this->touchToRefresh);
+			}
+
+			$presenter = $this->container->createInstance($class);
+			$this->container->callInjects($presenter);
+			if ($presenter instanceof Nette\Application\UI\Presenter && $presenter->invalidLinkMode === NULL) {
+				$presenter->invalidLinkMode = $this->invalidLinkMode;
+			}
+			return $presenter;
+		}
+
+		return $this->container->createService($services[0]);
+	}
+
+}

--- a/tests/Application.DI/ApplicationExtension.invalidLink.phpt
+++ b/tests/Application.DI/ApplicationExtension.invalidLink.phpt
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Test: ApplicationExtension
+ */
+
+use Nette\DI,
+	Nette\Bridges\ApplicationDI\ApplicationExtension,
+	Nette\Application\UI\Presenter,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/files/MyPresenter.php';
+
+
+function createCompiler($config)
+{
+	$compiler = new DI\Compiler;
+	$compiler->loadConfig(Tester\FileMock::create($config, 'neon'));
+	$builder = $compiler->getContainerBuilder();
+	$builder->addDefinition('myRouter')->setClass('Nette\Application\Routers\SimpleRouter');
+	$builder->addDefinition('myHttpRequest')->setFactory('Nette\Http\Request', array(new DI\Statement('Nette\Http\UrlScript')));
+	$builder->addDefinition('myHttpResponse')->setClass('Nette\Http\Response');
+	return $compiler;
+}
+
+
+test(function() {
+	$compiler = createCompiler('
+	application:
+		debugger: no
+		silentLinks: yes
+
+	services:
+		presenter: Presenter1
+	');
+	$compiler->addExtension('application', new ApplicationExtension(TRUE));
+	$code = $compiler->compile(NULL, 'Container4');
+	eval($code);
+
+	$container = new Container4;
+	Assert::same(
+		Presenter::INVALID_LINK_TEXTUAL,
+		$container->getService('presenter')->invalidLinkMode
+	);
+});
+
+
+test(function() {
+	$compiler = createCompiler('
+	application:
+		debugger: no
+		silentLinks: no
+
+	services:
+		presenter: Presenter1
+	');
+	$compiler->addExtension('application', new ApplicationExtension(TRUE));
+	$code = $compiler->compile(NULL, 'Container5');
+	eval($code);
+
+	$container = new Container5;
+	Assert::same(
+		Presenter::INVALID_LINK_WARNING | Presenter::INVALID_LINK_TEXTUAL,
+		$container->getService('presenter')->invalidLinkMode
+	);
+});
+
+
+test(function() {
+	$compiler = createCompiler('
+	application:
+		debugger: no
+		silentLinks: yes
+
+	services:
+		presenter: Presenter1
+	');
+	$compiler->addExtension('application', new ApplicationExtension(FALSE));
+	$code = $compiler->compile(NULL, 'Container6');
+	eval($code);
+
+	$container = new Container6;
+	Assert::same(
+		Presenter::INVALID_LINK_WARNING,
+		$container->getService('presenter')->invalidLinkMode
+	);
+});
+
+
+test(function() {
+	$compiler = createCompiler('
+	application:
+		debugger: no
+		silentLinks: no
+
+	services:
+		presenter: Presenter1
+	');
+	$compiler->addExtension('application', new ApplicationExtension(FALSE));
+	$code = $compiler->compile(NULL, 'Container7');
+	eval($code);
+
+	$container = new Container7;
+	Assert::same(
+		Presenter::INVALID_LINK_WARNING,
+		$container->getService('presenter')->invalidLinkMode
+	);
+});

--- a/tests/Application.Routers/LinkGenerator.phpt
+++ b/tests/Application.Routers/LinkGenerator.phpt
@@ -42,7 +42,7 @@ namespace {
 		Tester\Assert;
 
 
-	$pf = new PresenterFactory(new Nette\DI\Container);
+	$pf = new PresenterFactory;
 
 
 	test(function() use ($pf) {

--- a/tests/Application/Presenter.link().phpt
+++ b/tests/Application/Presenter.link().phpt
@@ -77,6 +77,7 @@ class TestPresenter extends Application\UI\Presenter
 	{
 		parent::startup();
 		$this['mycontrol'] = new TestControl;
+		$this->invalidLinkMode = self::INVALID_LINK_TEXTUAL;
 
 		// Presenter & action link
 		Assert::same( '/index.php?action=product&presenter=Test', $this->link('product', array('var1' => $this->var1)) );
@@ -133,6 +134,23 @@ class TestPresenter extends Application\UI\Presenter
 		$this['mycontrol']->order = 1;
 		Assert::same( "#error: Invalid value for persistent parameter 'order' in 'mycontrol', expected array.", $this['mycontrol']->link('click') );
 		$this['mycontrol']->order = NULL;
+
+		// silent invalid link mode
+		$this->invalidLinkMode = self::INVALID_LINK_SILENT;
+		Assert::same('#', $this->link('product', array('var1' => null, 'ok' => 'a')));
+
+		// warning invalid link mode
+		$this->invalidLinkMode = self::INVALID_LINK_WARNING;
+		$me = $this;
+		Assert::error(function() use ($me) {
+			Assert::same('#', $me->link('product', array('var1' => null, 'ok' => 'a')));
+		}, E_USER_WARNING, "Invalid link: Invalid value for persistent parameter 'ok' in 'Test', expected boolean.");
+
+		// exception invalid link mode
+		$this->invalidLinkMode = self::INVALID_LINK_EXCEPTION;
+		Assert::exception(function() use ($me) {
+			$me->link('product', array('var1' => null, 'ok' => 'a'));
+		}, 'Nette\Application\UI\InvalidLinkException', "Invalid value for persistent parameter 'ok' in 'Test', expected boolean.");
 	}
 
 

--- a/tests/Application/PresenterFactory.formatPresenterClass.phpt
+++ b/tests/Application/PresenterFactory.formatPresenterClass.phpt
@@ -12,7 +12,7 @@ require __DIR__ . '/../bootstrap.php';
 
 
 test(function() {
-	$factory = new PresenterFactory(new Nette\DI\Container);
+	$factory = new PresenterFactory;
 
 	$factory->setMapping(array(
 		'Foo2' => 'App2\*\*Presenter',
@@ -35,7 +35,7 @@ test(function() {
 
 
 test(function() {
-	$factory = new PresenterFactory(new Nette\DI\Container);
+	$factory = new PresenterFactory;
 
 	$factory->setMapping(array(
 		'Foo2' => 'App2\*Presenter',

--- a/tests/Application/PresenterFactory.unformatPresenterClass.phpt
+++ b/tests/Application/PresenterFactory.unformatPresenterClass.phpt
@@ -11,7 +11,7 @@ use Nette\Application\PresenterFactory,
 require __DIR__ . '/../bootstrap.php';
 
 
-$factory = new PresenterFactory(new Nette\DI\Container);
+$factory = new PresenterFactory;
 
 test(function() use ($factory) {
 	$factory->setMapping(array(


### PR DESCRIPTION
Two different things.

1) replaced PresenterFactory dependency on DI with simple callback. 
- dependency on DIC is bad (it is the only one dependency on DIC in whole framework)
- current PresenterFactory constructor is different in 2.2 and 2.3, so there will still be BC break
- partially solves #16 

2) new invalidLinkMode
- handling of invalid links is not insufficient, we need warnings
- I am not happy with #65, where (for partial combatibility) is mode that triggers warnings named `INVALID_LINK_SILENT`