### PR TITLE
composer.json: requires RobotLoader ~2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"nette/di": "~2.3",
 		"nette/http": "~2.2",
 		"nette/reflection": "~2.2",
+		"nette/robot-loader": "~2.2",
 		"nette/security": "~2.2",
 		"nette/utils": "~2.2"
 	},


### PR DESCRIPTION
ApplicationExtension doesn't work without RobotLoader. (Unless you disable scanDirs option.)