### PR TITLE
Proper enconding of Content-Dispisition filename

### DIFF
--- a/src/Application/Responses/FileResponse.php
+++ b/src/Application/Responses/FileResponse.php
@@ -93,7 +93,9 @@ class FileResponse extends Nette\Object implements Nette\Application\IResponse
 	{
 		$httpResponse->setContentType($this->contentType);
 		$httpResponse->setHeader('Content-Disposition',
-			($this->forceDownload ? 'attachment' : 'inline') . '; filename="' . $this->name . '"');
+			($this->forceDownload ? 'attachment' : 'inline')
+				. '; filename="' . $this->name . '"'
+				. '; filename*=utf-8\'\'' . rawurlencode($this->name));
 
 		$filesize = $length = filesize($this->file);
 		$handle = fopen($this->file, 'r');

--- a/tests/Application/FileResponse.contentDisposition.phpt
+++ b/tests/Application/FileResponse.contentDisposition.phpt
@@ -28,7 +28,7 @@ test(function() {
 	$fileResponse->send(new Http\Request(new Http\UrlScript), $response = new Http\Response);
 
 	Assert::same( $origData, ob_get_clean() );
-	Assert::same( 'attachment; filename="' . $fileName . '"', $response->getHeader('Content-Disposition') );
+	Assert::same( 'attachment; filename="' . $fileName . '"; filename*=utf-8\'\'' . rawurlencode($fileName), $response->getHeader('Content-Disposition') );
 });
 
 
@@ -44,5 +44,19 @@ test(function() {
 	$fileResponse->send(new Http\Request(new Http\UrlScript), $response = new Http\Response);
 
 	Assert::same( $origData, ob_get_clean() );
-	Assert::same('inline; filename="' . $fileName . '"', $response->getHeader('Content-Disposition'));
+	Assert::same('inline; filename="' . $fileName . '"; filename*=utf-8\'\'' . rawurlencode($fileName), $response->getHeader('Content-Disposition'));
+});
+
+
+test(function() {
+	$file = __FILE__;
+	$fileName = 'žluťoučký kůň.txt';
+	$fileResponse = new FileResponse($file, $fileName);
+	$origData = file_get_contents($file);
+
+	ob_start();
+	$fileResponse->send(new Http\Request(new Http\UrlScript), $response = new Http\Response);
+
+	Assert::same( $origData, ob_get_clean() );
+	Assert::same('attachment; filename="' . $fileName . '"; filename*=utf-8\'\'' . rawurlencode($fileName), $response->getHeader('Content-Disposition'));
 });


### PR DESCRIPTION
According to RFC 5987 Content-Disposition filename should not contain non-US-ASCII characters.

Proper way to encode filename is this:
"filename*=utf-8''%C5%BElu%C5%A5ou%C4%8Dk%C3%BD%20k%C5%AF%C5%88.txt".

Unfortunately, RFC 5987 is not supported by all browsers, so for compatibility reasons, filename should be sent like this:
"filename=žluťoučký kůň.txt; filename*=utf-8''%C5%BElu%C5%A5ou%C4%8Dk%C3%BD%20k%C5%AF%C5%88.txt".

Some discussion about this is here: http://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http