### PR TITLE
ApplicationExtension: Change linkGenerator dependency from Nette\Http\Request to Nette\Http\IRequest

### DIFF
--- a/src/Bridges/ApplicationDI/ApplicationExtension.php
+++ b/src/Bridges/ApplicationDI/ApplicationExtension.php
@@ -81,7 +81,7 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 
 		$container->addDefinition($this->prefix('linkGenerator'))
 			->setFactory('Nette\Application\LinkGenerator', array(
-				1 => new Nette\DI\Statement('@Nette\Http\Request::getUrl'),
+				1 => new Nette\DI\Statement('@Nette\Http\IRequest::getUrl'),
 			));
 
 		if ($this->name === 'application') {


### PR DESCRIPTION
- feature
- documentation - not needed
- BC breaks - no

Needed for testing with phpunit (using Mock object)