### PR TITLE
phpdoc: typo in param callable

### DIFF
--- a/src/Application/UI/Multiplier.php
+++ b/src/Application/UI/Multiplier.php
@@ -22,7 +22,7 @@ class Multiplier extends PresenterComponent
 
 
 	/**
-	 * @param callable
+	 * @param callable|Nette\ComponentModel\IContainer $factory
 	 */
 	public function __construct($factory)
 	{


### PR DESCRIPTION
better support in PhpStorm.
![85ca6b60-e83d-11e4-88d2-8ce08c6cfb48](https://cloud.githubusercontent.com/assets/382475/7253921/156ee186-e840-11e4-902a-14667e80856d.png)
