### PR TITLE
Application: Availability of invalid request for ErrorPresenter

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -117,14 +117,14 @@ class Application extends Nette\Object
 			throw new BadRequestException('No route for HTTP request.');
 
 		} elseif (strcasecmp($request->getPresenterName(), $this->errorPresenter) === 0) {
-			throw new BadRequestException('Invalid request. Presenter is not achievable.');
+			throw BadRequestException::fromRequest($request, 'Invalid request. Presenter is not achievable.');
 		}
 
 		try {
 			$name = $request->getPresenterName();
 			$this->presenterFactory->getPresenterClass($name);
 		} catch (InvalidPresenterException $e) {
-			throw new BadRequestException($e->getMessage(), 0, $e);
+			throw BadRequestException::fromRequest($request, $e->getMessage(), 0, $e);
 		}
 
 		return $request;
@@ -169,7 +169,7 @@ class Application extends Nette\Object
 			$this->httpResponse->setCode($e instanceof BadRequestException ? ($e->getCode() ?: 404) : 500);
 		}
 
-		$args = ['exception' => $e, 'request' => end($this->requests) ?: NULL];
+		$args = ['exception' => $e, 'request' => $e->getRequest() ?: (end($this->requests) ?: NULL)];
 		if ($this->presenter instanceof UI\Presenter) {
 			try {
 				$this->presenter->forward(":$this->errorPresenter:", $args);

--- a/src/Application/exceptions.php
+++ b/src/Application/exceptions.php
@@ -44,9 +44,29 @@ class BadRequestException extends \Exception
 	protected $code = 404;
 
 
-	public function __construct($message = '', $code = 0, \Exception $previous = NULL)
+	/** @var Request */
+	private $request;
+
+
+	public function __construct($message = '', $code = 0, \Exception $previous = NULL, Request $request = NULL)
 	{
 		parent::__construct($message, $code < 200 || $code > 504 ? $this->code : $code, $previous);
+		$this->request = $request;
+	}
+
+
+	/**
+	 * @return Request|null
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+
+	public static function fromRequest(Request $request, $message = '', $code = 0, \Exception $previous = NULL)
+	{
+		return new static($message, $code, $previous, $request);
 	}
 
 }


### PR DESCRIPTION
Currently if the initial request is invalid, there is no way for the ErrorPresenter to know what the initial request was. Or in case there is a [mechanic to use per-module ErrorPresenters](https://github.com/enumag/Application/blob/master/src/Application.php#L58-L90) it will fail to call the correct module-specific ErrorPresenter.

For these reasons I believe that the initial request should be available even if it is not valid.

(Just to be clear, I'm not looking for hack suggestions. I'm well aware I can hack it using `$request = $this->router->match($this->httpRequest);` in case the array is empty or just override the createInitialRequest method.)
