### PR TITLE
Presenter: removed static from refUrl variable

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -126,6 +126,9 @@ abstract class Presenter extends Control implements Application\IPresenter
 	/** @var ITemplateFactory */
 	private $templateFactory;
 
+	/** @var Nette\Http\Url */
+	private $refUrlCache;
+
 
 	public function __construct()
 	{
@@ -973,9 +976,9 @@ abstract class Presenter extends Control implements Application\IPresenter
 		}
 
 		// CONSTRUCT URL
-		static $refUrl;
+		$refUrl = $this->refUrlCache;
 		if ($refUrl === NULL) {
-			$refUrl = new Http\Url($this->httpRequest->getUrl());
+			$this->refUrlCache = $refUrl = new Http\Url($this->httpRequest->getUrl());
 			$refUrl->setPath($this->httpRequest->getUrl()->getScriptPath());
 		}
 		if (!$this->router) {

--- a/tests/Application/Presenter.twoDomains.phpt
+++ b/tests/Application/Presenter.twoDomains.phpt
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Test: Nette\Application\UI\Presenter::link()
+ */
+
+use Nette\Http,
+	Nette\Application,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class TestPresenter extends Application\UI\Presenter
+{
+
+	protected function createTemplate($class = NULL)
+	{
+	}
+
+}
+
+class MockPresenterFactory extends Nette\Object implements Nette\Application\IPresenterFactory
+{
+	function getPresenterClass(& $name)
+	{
+		return str_replace(':', 'Module\\', $name) . 'Presenter';
+	}
+
+	function createPresenter($name)
+	{}
+}
+
+function testLink($domain)
+{
+	$url = new Http\UrlScript('http://' . $domain . '/index.php');
+	$url->setScriptPath('/index.php');
+
+	$presenter = new TestPresenter;
+	$presenter->injectPrimary(
+		NULL,
+		new MockPresenterFactory,
+		new Application\Routers\SimpleRouter,
+		new Http\Request($url),
+		new Http\Response
+	);
+
+	$request = new Application\Request('Test', Http\Request::GET, []);
+	$presenter->run($request);
+
+	Assert::same( 'http://' . $domain . '/index.php?action=default&presenter=Test', $presenter->link('//this') );
+}
+
+testLink('first.localhost');
+testLink('second.localhost');


### PR DESCRIPTION
- bugfix
- documentation - not needed
- BC break - no

The pull request fixes issue when testing presenters without isolation: You make two presenter calls with Nette\Http\Request-s on different domains - the first domain is cached for whole class (and not only instance) and so the second instance of the same presenter will redirect you to the first domain.
The test is appended mainly as example (there's no problem to remove it if it's not needed).