### PR TITLE
Add missing use definition in ILatteFactory

### DIFF
--- a/src/Bridges/ApplicationLatte/ILatteFactory.php
+++ b/src/Bridges/ApplicationLatte/ILatteFactory.php
@@ -7,6 +7,8 @@
 
 namespace Nette\Bridges\ApplicationLatte;
 
+use Latte;
+
 
 interface ILatteFactory
 {


### PR DESCRIPTION
After removing use definition from Nette\Bridges\ApplicationLatte\ILatteFactory was created a undefined namespace for Latte\Engine.
Resolve #84