### PR TITLE
ApplicationExtension should not disable autowiring of general IPresenter service

### DIFF
--- a/src/Bridges/ApplicationDI/ApplicationExtension.php
+++ b/src/Bridges/ApplicationDI/ApplicationExtension.php
@@ -106,9 +106,9 @@ class ApplicationExtension extends Nette\DI\CompilerExtension
 		}
 
 		foreach ($all as $def) {
-			$def->setInject(TRUE)->setAutowired(FALSE)->addTag('nette.presenter', $def->getClass());
+			$def->setInject(TRUE)->addTag('nette.presenter', $def->getClass());
 			if (is_subclass_of($def->getClass(), 'Nette\Application\UI\Presenter')) {
-				$def->addSetup('$invalidLinkMode', [$this->invalidLinkMode]);
+				$def->setAutowired(FALSE)->addSetup('$invalidLinkMode', [$this->invalidLinkMode]);
 			}
 		}
 	}


### PR DESCRIPTION
ApplicationExtension currently [disables autowiring](https://github.com/nette/application/blob/1ecd8ed01e369f183150a171d949e4e25a22967f/src/Bridges/ApplicationDI/ApplicationExtension.php#L109) of all services which implement `IPresenter`. This seems like too aggressive decision, it should only be done for `UI\Presenter` descendants.

cc @mikulas