### PR TITLE
Echo return of control render methods

### DIFF
--- a/src/Bridges/ApplicationLatte/UIMacros.php
+++ b/src/Bridges/ApplicationLatte/UIMacros.php
@@ -76,7 +76,7 @@ if (empty($_l->extends) && !empty($_control->snippetMode)) {
 		return ($name[0] === '$' ? "if (is_object($name)) \$_l->tmp = $name; else " : '')
 			. '$_l->tmp = $_control->getComponent(' . $name . '); '
 			. 'if ($_l->tmp instanceof Nette\Application\UI\IRenderable) $_l->tmp->redrawControl(NULL, FALSE); '
-			. ($node->modifiers === '' ? "\$_l->tmp->$method($param)" : $writer->write("ob_start(); \$_l->tmp->$method($param); echo %modify(ob_get_clean())"));
+			. ($node->modifiers === '' ? "echo \$_l->tmp->$method($param)" : $writer->write("ob_start(); echo \$_l->tmp->$method($param); echo %modify(ob_get_clean())"));
 	}
 
 


### PR DESCRIPTION
See http://forum.nette.org/cs/17928-rfc-komponenty-ktere-se-samy-nevykresluji-ale-jen-vraceji-view#p160254

This change will allow component to instead of directly render itslef to return object representing component view. This view than can by examined in tests before it is rendered. 

Render methods does not return anything yet so this sould not be BC break.