### PR TITLE
Router: Have a routes collection interface & support in Tracy router panel

### DIFF
--- a/src/Application/IRouteList.php
+++ b/src/Application/IRouteList.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Application;
+
+use Nette;
+
+
+/**
+ * Routes collection.
+ */
+interface IRouteList extends \IteratorAggregate
+{
+	/**
+	 * @return string
+	 */
+	function getModule();
+
+}

--- a/src/Application/Routers/RouteList.php
+++ b/src/Application/Routers/RouteList.php
@@ -13,7 +13,7 @@ use Nette;
 /**
  * The router broker.
  */
-class RouteList extends Nette\Utils\ArrayList implements Nette\Application\IRouter
+class RouteList extends Nette\Utils\ArrayList implements Nette\Application\IRouter, Nette\Application\IRouteList
 {
 	/** @var array */
 	private $cachedRoutes;

--- a/src/Bridges/ApplicationTracy/RoutingPanel.php
+++ b/src/Bridges/ApplicationTracy/RoutingPanel.php
@@ -96,7 +96,7 @@ class RoutingPanel extends Nette\Object implements Tracy\IBarPanel
 	 */
 	private function analyse($router, $module = '')
 	{
-		if ($router instanceof Routers\RouteList) {
+		if ($router instanceof Nette\Application\IRouteList) {
 			foreach ($router as $subRouter) {
 				$this->analyse($subRouter, $module . $router->getModule());
 			}


### PR DESCRIPTION
* Feature
* Documentation – No change needed, unless you want to mention it in the "Custom Router" chapter.
* BC break - no

Currently, the only way to have a collection of routes and have them displayed in the Tracy panel is to use the ```RouteList``` class.

This PR generalizes this logic to allow developers to implement their own route collections maybe with some logic inside (the ```RouteList``` is just a simple hashmap), maybe immutable (```RouteList``` is mutable), etc. It comes from our use case but I believe it could be useful for others, too.

* This PR introduces a new interface for route lists that extends ```IteratorAggregate``` (which is the easiest way to implement a ```Traversable```) and adds the ```getModule()``` method that is required by the Tracy panel.
* Because of the way ```RouteList``` is implemented, it can implement this new interface without any changes.
* And the last change is the ```instanceof``` typecheck in the Panel to display a routes collection.