### PR TITLE
SimpleRouter: add support for $defaultFlags

### DIFF
--- a/src/Application/Routers/SimpleRouter.php
+++ b/src/Application/Routers/SimpleRouter.php
@@ -19,6 +19,9 @@ class SimpleRouter extends Nette\Object implements Application\IRouter
 	const PRESENTER_KEY = 'presenter';
 	const MODULE_KEY = 'module';
 
+	/** @var int */
+	public static $defaultFlags = 0;
+
 	/** @var string */
 	private $module = '';
 
@@ -52,7 +55,7 @@ class SimpleRouter extends Nette\Object implements Application\IRouter
 		}
 
 		$this->defaults = $defaults;
-		$this->flags = $flags;
+		$this->flags = $flags | static::$defaultFlags;
 	}
 
 


### PR DESCRIPTION
My use case is as described here: https://forum.nette.org/cs/3184-https-mi-automaticky-presmeruje-na-http#p93043

Its a private project, so SimpleRouter is good enough and it is running https on server and http on local machine.