### PR TITLE
Fix Presenter::argsToParams to not remove false

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -1047,7 +1047,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 				));
 			}
 
-			if ($args[$name] === $def || ($def === NULL && is_scalar($args[$name]) && (string) $args[$name] === '')) {
+			if ($args[$name] === $def || ($def === NULL && $args[$name] === '')) {
 				$args[$name] = NULL; // value transmit is unnecessary
 			}
 		}

--- a/tests/UI/Presenter.link().php7.phpt
+++ b/tests/UI/Presenter.link().php7.phpt
@@ -33,7 +33,7 @@ class TestPresenter extends Application\UI\Presenter
 		Assert::same('/index.php?var1=20&action=default&do=hint&presenter=Test', $this->link('hint!', ['var1' => $this->var1 * 2]));
 		Assert::same('/index.php?y=2&action=default&do=hint&presenter=Test', $this->link('hint!', 1, 2));
 		Assert::same('/index.php?y=2&bool=1&str=1&action=default&do=hint&presenter=Test', $this->link('hint!', '1', '2', TRUE, TRUE));
-		Assert::same('/index.php?y=2&str=0&action=default&do=hint&presenter=Test', $this->link('hint!', '1', '2', FALSE, FALSE));
+		Assert::same('/index.php?y=2&bool=0&str=0&action=default&do=hint&presenter=Test', $this->link('hint!', '1', '2', FALSE, FALSE));
 		Assert::same('/index.php?action=default&do=hint&presenter=Test', $this->link('hint!', [1]));
 		Assert::same('#error: Argument $x passed to TestPresenter::handleHint() must be int, array given.', $this->link('hint!', [1], (object) [1]));
 		Assert::same('/index.php?y=2&action=default&do=hint&presenter=Test', $this->link('hint!', [1, 'y' => 2]));

--- a/tests/UI/Presenter.link().phpt
+++ b/tests/UI/Presenter.link().phpt
@@ -135,7 +135,7 @@ class TestPresenter extends Application\UI\Presenter
 		Assert::same('/index.php?mycontrol-x=0a&mycontrol-y=1a&action=default&do=mycontrol-click&presenter=Test', $this['mycontrol']->link('click', '0a', '1a'));
 		Assert::same('/index.php?mycontrol-x=1&action=default&do=mycontrol-click&presenter=Test', $this['mycontrol']->link('click', [1]));
 		Assert::same('#error: Argument $x passed to TestControl::handleClick() must be scalar, array given.', $this['mycontrol']->link('click', [1], (object) [1]));
-		Assert::same('/index.php?mycontrol-x=1&action=default&do=mycontrol-click&presenter=Test', $this['mycontrol']->link('click', TRUE, FALSE));
+		Assert::same('/index.php?mycontrol-x=1&mycontrol-y=0&action=default&do=mycontrol-click&presenter=Test', $this['mycontrol']->link('click', TRUE, FALSE));
 		Assert::same('/index.php?action=default&do=mycontrol-click&presenter=Test', $this['mycontrol']->link('click', NULL, ''));
 		Assert::same('#error: Passed more parameters than method TestControl::handleClick() expects.', $this['mycontrol']->link('click', 1, 2, 3));
 		Assert::same('/index.php?mycontrol-x=1&mycontrol-y=2&action=default&do=mycontrol-click&presenter=Test', $this['mycontrol']->link('click!', ['x' => 1, 'y' => 2, 'round' => 0]));


### PR DESCRIPTION
I sometimes use boolean parameters in presenters and I want the `param=0` part in the URL because `FALSE` and `NULL` are totally different values for me. Right now however argsToParams replaces false values with nulls which breaks my use case.