### PR TITLE
json response: removed automatic cache disabling

### DIFF
--- a/src/Application/Responses/JsonResponse.php
+++ b/src/Application/Responses/JsonResponse.php
@@ -62,7 +62,6 @@ class JsonResponse extends Nette\Object implements Nette\Application\IResponse
 	public function send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse)
 	{
 		$httpResponse->setContentType($this->contentType);
-		$httpResponse->setExpiration(FALSE);
 		echo Nette\Utils\Json::encode($this->payload);
 	}
 


### PR DESCRIPTION
The json output isn't something special what shouldn't be cached at all. If disabling of cache is needed, this should be handled by Nette Presenter itself.

It's probably BC Break.