### PR TITLE
Set default JsonResponse charset to utf-8.

### DIFF
--- a/src/Application/Responses/JsonResponse.php
+++ b/src/Application/Responses/JsonResponse.php
@@ -61,7 +61,7 @@ class JsonResponse extends Nette\Object implements Nette\Application\IResponse
 	 */
 	public function send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse)
 	{
-		$httpResponse->setContentType($this->contentType);
+		$httpResponse->setContentType($this->contentType, 'utf-8');
 		echo Nette\Utils\Json::encode($this->payload);
 	}
 

--- a/tests/Responses/JsonResponse.contentType.phpt
+++ b/tests/Responses/JsonResponse.contentType.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Nette\Application\Responses\JsonResponse.
+ */
+
+use Nette\Application\Responses\JsonResponse;
+use Nette\Http;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+if (PHP_SAPI === 'cli') {
+	Tester\Environment::skip('Requires CGI SAPI to work with HTTP headers.');
+}
+
+test(function () {
+	$data = [ 'text' => 'žluťoučký kůň'];
+	$encoded = json_encode($data, JSON_UNESCAPED_UNICODE);
+	$jsonResponse = new JsonResponse($data, 'application/json');
+
+	ob_start();
+	$jsonResponse->send(new Http\Request(new Http\UrlScript), $response = new Http\Response);
+
+	Assert::same($encoded, ob_get_clean());
+	Assert::same('application/json; charset=utf-8', $response->getHeader('Content-Type'));
+});


### PR DESCRIPTION
- bugfix
- issues #120 
- documentation - not needed
- BC break - yes (removes unintended feature see [Nette Forum discussion (in Czech)](https://forum.nette.org/cs/25615-cestina-v-jsonu-se-nezobrazuje-korektne))