### PR TITLE
Fix wrong MicroPresenter module

### DIFF
--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -125,7 +125,7 @@ class Route extends Nette\Object implements Application\IRouter
 				trigger_error('Nette\Callback is deprecated, use Nette\Utils\Callback::toClosure().', E_USER_DEPRECATED);
 			}
 			$metadata = [
-				self::PRESENTER_KEY => 'Nette:Micro',
+				self::PRESENTER_KEY => 'NetteModule:Micro',
 				'callback' => $metadata,
 			];
 		}

--- a/tests/Routers/Route.closure.phpt
+++ b/tests/Routers/Route.closure.phpt
@@ -16,7 +16,7 @@ require __DIR__ . '/Route.php';
 $closure = function() {};
 $route = new Route('<id>', $closure);
 
-testRouteIn($route, '/12', 'Nette:Micro', [
+testRouteIn($route, '/12', 'NetteModule:Micro', [
 	'id' => '12',
 	'test' => 'testvalue',
 	'callback' => $closure,


### PR DESCRIPTION
Before this change I was getting error `Case mismatch on presenter name 'Nette:Micro', correct name is 'NetteModule:Micro'.`

I hope this is correct change - it is the first time I'm using the MicroPresenter. 

My usage was as simple as:
```
$this[] = new Route('/', function() {
    // some simple stuff
});
```