### PR TITLE
VaribaleTemplate: add getParameters() method to improve back compatability

### DIFF
--- a/src/Bridges/ApplicationLatte/VariableTemplate.php
+++ b/src/Bridges/ApplicationLatte/VariableTemplate.php
@@ -78,4 +78,14 @@ class VariableTemplate extends Latte\Template
 		unset($this->template->params[$name]);
 	}
 
+
+	/**
+	 * Returns array of all parameters.
+	 * @return array
+	 */
+	public function getParameters()
+	{
+		return $this->template->getParameters();
+	}
+
 }


### PR DESCRIPTION
Quite a few custom macros use something like: https://github.com/brabijan/images/blob/master/src/Brabijan/Images/Macros/Latte.php#L138