### PR TITLE
Control - snippets: prevents multiple rendering of nested snippets

### DIFF
--- a/src/Application/UI/Control.php
+++ b/src/Application/UI/Control.php
@@ -112,7 +112,7 @@ abstract class Control extends PresenterComponent implements IRenderable
 			$this->invalidSnippets = [];
 
 		} else {
-			unset($this->invalidSnippets[$snippet]);
+			$this->invalidSnippets[$snippet] = FALSE;
 		}
 	}
 
@@ -160,8 +160,10 @@ abstract class Control extends PresenterComponent implements IRenderable
 				return FALSE;
 			}
 
+		} elseif (isset($this->invalidSnippets[$snippet])) {
+			return $this->invalidSnippets[$snippet];
 		} else {
-			return isset($this->invalidSnippets["\0"]) || isset($this->invalidSnippets[$snippet]);
+			return isset($this->invalidSnippets["\0"]);
 		}
 	}
 

--- a/tests/Bridges.Latte/UIMacros.renderSnippets.phpt
+++ b/tests/Bridges.Latte/UIMacros.renderSnippets.phpt
@@ -62,6 +62,7 @@ Assert::same([
 		'snippet--array2-3' => 'Value 3',
 		'snippet--includeSay' => 'Hello include snippet',
 		'snippet-multi-1-includeSay' => 'Hello',
+		'snippet--nested1' => "\t<div id=\"snippet--nested2\">Foo</div>",
 	],
 ], (array) $presenter->payload);
 

--- a/tests/Bridges.Latte/expected/UIMacros.renderSnippets.html
+++ b/tests/Bridges.Latte/expected/UIMacros.renderSnippets.html
@@ -11,3 +11,4 @@
 		<div id="snippet--array2-3">Value 3</div>
 
 <div id="snippet--includeSay">Hello include snippet</div>
+<div id="snippet--nested1">	<div id="snippet--nested2">Foo</div></div>

--- a/tests/Bridges.Latte/templates/snippet-include.latte
+++ b/tests/Bridges.Latte/templates/snippet-include.latte
@@ -19,3 +19,7 @@
 {snippetArea}
 	{include snippet-included.latte say => 'Hello include snippet'}
 {/snippetArea}
+
+{snippet nested1}
+	{snippet nested2}Foo{/snippet}
+{/snippet}


### PR DESCRIPTION
Nested snippets were rendered multiple times when you used `->redrawControl()` without snippet name.

ref https://github.com/ublaboo/datagrid/issues/241

It should not be a BC break