### PR TITLE
FIX: Unescaped preg_match_all parameter

### DIFF
--- a/src/Application/UI/ComponentReflection.php
+++ b/src/Application/UI/ComponentReflection.php
@@ -195,7 +195,7 @@ class ComponentReflection extends \ReflectionClass
 	 */
 	public static function parseAnnotation(\Reflector $ref, $name)
 	{
-		if (!preg_match_all('#[\\s*]@' . preg_quote($name) . '(?:\(\\s*([^)]*)\\s*\))?#', $ref->getDocComment(), $m)) {
+		if (!preg_match_all('#[\\s*]@' . preg_quote($name, '#') . '(?:\(\\s*([^)]*)\\s*\))?#', $ref->getDocComment(), $m)) {
 			return FALSE;
 		}
 		static $tokens = ['true' => TRUE, 'false' => FALSE, 'null' => NULL];

--- a/src/Application/UI/ComponentReflection.php
+++ b/src/Application/UI/ComponentReflection.php
@@ -195,7 +195,7 @@ class ComponentReflection extends \ReflectionClass
 	 */
 	public static function parseAnnotation(\Reflector $ref, $name)
 	{
-		if (!preg_match_all("#[\\s*]@$name(?:\(\\s*([^)]*)\\s*\))?#", $ref->getDocComment(), $m)) {
+		if (!preg_match_all("#[\\s*]@' . preg_quote($name) . '(?:\(\\s*([^)]*)\\s*\))?#", $ref->getDocComment(), $m)) {
 			return FALSE;
 		}
 		static $tokens = ['true' => TRUE, 'false' => FALSE, 'null' => NULL];

--- a/src/Application/UI/ComponentReflection.php
+++ b/src/Application/UI/ComponentReflection.php
@@ -195,7 +195,7 @@ class ComponentReflection extends \ReflectionClass
 	 */
 	public static function parseAnnotation(\Reflector $ref, $name)
 	{
-		if (!preg_match_all("#[\\s*]@' . preg_quote($name) . '(?:\(\\s*([^)]*)\\s*\))?#", $ref->getDocComment(), $m)) {
+		if (!preg_match_all('#[\\s*]@' . preg_quote($name) . '(?:\(\\s*([^)]*)\\s*\))?#', $ref->getDocComment(), $m)) {
 			return FALSE;
 		}
 		static $tokens = ['true' => TRUE, 'false' => FALSE, 'null' => NULL];

--- a/tests/UI/ComponentReflection.parseAnnotation.phpt
+++ b/tests/UI/ComponentReflection.parseAnnotation.phpt
@@ -22,6 +22,7 @@ require __DIR__ . '/../bootstrap.php';
  * @author
  *@renderable
  * @secured(role = "admin", level = 2)
+ * @Secured\User(loggedIn)
  */
 class TestClass {}
 
@@ -32,4 +33,5 @@ Assert::same(['value ="Johno\'s addendum"', 'mode=True', TRUE, TRUE], Reflection
 Assert::same(['item 1'], Reflection::parseAnnotation($rc, 'components'));
 Assert::same([TRUE, FALSE, NULL], Reflection::parseAnnotation($rc, 'persistent'));
 Assert::same([TRUE], Reflection::parseAnnotation($rc, 'renderable'));
+Assert::same(['loggedIn'], Reflection::parseAnnotation($rc, 'Secured\User'));
 Assert::false(Reflection::parseAnnotation($rc, 'missing'));


### PR DESCRIPTION
Fixed unescaped annotation name $name in preg_match_all function $pattern parameter. (Causing errors if annotation is like @Secured\User - ipub/permissions package)