### PR TITLE
ComponentReflection::parseAnnotation: fix false positive annotation parsing

### DIFF
--- a/src/Application/UI/ComponentReflection.php
+++ b/src/Application/UI/ComponentReflection.php
@@ -195,7 +195,7 @@ class ComponentReflection extends \ReflectionClass
 	 */
 	public static function parseAnnotation(\Reflector $ref, $name)
 	{
-		if (!preg_match_all('#[\\s*]@' . preg_quote($name, '#') . '(?:\(\\s*([^)]*)\\s*\))?#', $ref->getDocComment(), $m)) {
+		if (!preg_match_all('#[\\s*]@' . preg_quote($name, '#') . '(?:\(\\s*([^)]*)\\s*\)|\\s|$)#', $ref->getDocComment(), $m)) {
 			return FALSE;
 		}
 		static $tokens = ['true' => TRUE, 'false' => FALSE, 'null' => NULL];

--- a/tests/UI/ComponentReflection.parseAnnotation.phpt
+++ b/tests/UI/ComponentReflection.parseAnnotation.phpt
@@ -15,6 +15,8 @@ require __DIR__ . '/../bootstrap.php';
  * @title(value ="Johno's addendum", mode=True,) , out
  * @title
  * @title()
+ * @publi - 'c' is missing intentionally
+ * @privatex
  * @components(item 1)
  * @persistent(true)
  * @persistent(FALSE)
@@ -30,6 +32,8 @@ class TestClass {}
 $rc = new ReflectionClass('TestClass');
 
 Assert::same(['value ="Johno\'s addendum"', 'mode=True', TRUE, TRUE], Reflection::parseAnnotation($rc, 'title'));
+Assert::same(FALSE, Reflection::parseAnnotation($rc, 'public'));
+Assert::same(FALSE, Reflection::parseAnnotation($rc, 'private'));
 Assert::same(['item 1'], Reflection::parseAnnotation($rc, 'components'));
 Assert::same([TRUE, FALSE, NULL], Reflection::parseAnnotation($rc, 'persistent'));
 Assert::same([TRUE], Reflection::parseAnnotation($rc, 'renderable'));


### PR DESCRIPTION
I know it's internal class, but I am using it anyway - so it's maybe my problem. And I know about this issue quite long, but [with this commit](https://github.com/nette/application/commit/03b8b34a0518b7adc09883564dccaacde738af22) I have to fix it. In current master you can have `@privatex` annotation and this test will pass:

```php
Assert::same([TRUE], Reflection::parseAnnotation($rc, 'private'));
```

But I don't think this is right. Previously I was calling it like this:

```php
$visible = ComponentReflection::parseAnnotation($actionReflection, 'public\\s');
```

But it's not possible now... :)