### PR TITLE
Fix possible PHP warning "strpos(): Offset not contained in string"

### DIFF
--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -392,6 +392,7 @@ class Route implements Application\IRouter
 			}
 		} while (TRUE);
 
+		$scheme = $this->scheme ?: $refUrl->getScheme();
 
 		if ($this->type === self::HOST) {
 			$host = $refUrl->getHost();
@@ -403,10 +404,9 @@ class Route implements Application\IRouter
 				'%sld%' => isset($parts[1]) ? $parts[1] : '',
 				'%host%' => $host,
 			]);
-			$url = ($this->scheme ?: $refUrl->getScheme()) . ':' . $url;
+			$url = $scheme . ':' . $url;
 		} else {
 			if ($this->lastRefUrl !== $refUrl) {
-				$scheme = ($this->scheme ?: $refUrl->getScheme());
 				$basePath = ($this->type === self::RELATIVE ? $refUrl->getBasePath() : '');
 				$this->lastBaseUrl = $scheme . '://' . $refUrl->getAuthority() . $basePath;
 				$this->lastRefUrl = $refUrl;
@@ -414,7 +414,7 @@ class Route implements Application\IRouter
 			$url = $this->lastBaseUrl . $url;
 		}
 
-		if (strpos($url, '//', 7) !== FALSE) {
+		if (strpos($url, '//', strlen($scheme) + 3) !== FALSE) {
 			return NULL;
 		}
 


### PR DESCRIPTION
It happened in some of my failing tests because `$refUrl->getScheme()` was empty for whatever reason.

Anyway a PHP warning should be fixed.