### PR TITLE
TemplateFactory: add support for custom Template implementation

### DIFF
--- a/src/Bridges/ApplicationDI/LatteExtension.php
+++ b/src/Bridges/ApplicationDI/LatteExtension.php
@@ -19,6 +19,7 @@ class LatteExtension extends Nette\DI\CompilerExtension
 	public $defaults = [
 		'xhtml' => FALSE,
 		'macros' => [],
+		'templateClass' => NULL
 	];
 
 	/** @var bool */
@@ -52,9 +53,12 @@ class LatteExtension extends Nette\DI\CompilerExtension
 			->addSetup('Nette\Utils\Html::$xhtml = ?', [(bool) $config['xhtml']])
 			->setImplement(Nette\Bridges\ApplicationLatte\ILatteFactory::class);
 
-		$builder->addDefinition($this->prefix('templateFactory'))
+		$templateFactory = $builder->addDefinition($this->prefix('templateFactory'))
 			->setClass(Nette\Application\UI\ITemplateFactory::class)
 			->setFactory(Nette\Bridges\ApplicationLatte\TemplateFactory::class);
+		if ($config['templateClass'] !== NULL) {
+			$templateFactory->addSetup('?->setTemplateClass(?)', ['@self', $config['templateClass']]);
+		}
 
 		foreach ($config['macros'] as $macro) {
 			if (strpos($macro, '::') === FALSE && class_exists($macro)) {

--- a/src/Bridges/ApplicationLatte/TemplateFactory.php
+++ b/src/Bridges/ApplicationLatte/TemplateFactory.php
@@ -31,6 +31,9 @@ class TemplateFactory implements UI\ITemplateFactory
 	/** @var Nette\Caching\IStorage */
 	private $cacheStorage;
 
+	/** @var string */
+	private $templateClass = Template::class;
+
 
 	public function __construct(ILatteFactory $latteFactory, Nette\Http\IRequest $httpRequest = NULL,
 		Nette\Security\User $user = NULL, Nette\Caching\IStorage $cacheStorage = NULL)
@@ -48,7 +51,7 @@ class TemplateFactory implements UI\ITemplateFactory
 	public function createTemplate(UI\Control $control = NULL)
 	{
 		$latte = $this->latteFactory->create();
-		$template = new Template($latte);
+		$template = new $this->templateClass($latte);
 		$presenter = $control ? $control->getPresenter(FALSE) : NULL;
 
 		if ($control instanceof UI\Presenter) {
@@ -110,6 +113,14 @@ class TemplateFactory implements UI\ITemplateFactory
 		}
 
 		return $template;
+	}
+
+	public function setTemplateClass($templateClass)
+	{
+		if (!class_exists($templateClass) || !is_a($templateClass, Template::class, TRUE)) {
+			throw new Nette\InvalidArgumentException("Class $templateClass does not extend " . Template::class . ' or it does not exist.');
+		}
+		$this->templateClass = $templateClass;
 	}
 
 }

--- a/tests/Bridges.Latte/TemplateFactory.customTemplate.phpt
+++ b/tests/Bridges.Latte/TemplateFactory.customTemplate.phpt
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Test: TemplateFactory custom template
+ */
+
+use Nette\Application\UI;
+use Nette\Bridges\ApplicationLatte\Template;
+use Nette\Bridges\ApplicationLatte\TemplateFactory;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class LatteFactoryMock implements Nette\Bridges\ApplicationLatte\ILatteFactory
+{
+	private $engine;
+
+	public function __construct(Latte\Engine $engine)
+	{
+		$this->engine = $engine;
+	}
+
+	public function create()
+	{
+		return $this->engine;
+	}
+}
+
+class TemplateMockWithoutImplement
+{
+
+}
+
+class TemplateMock extends Nette\Bridges\ApplicationLatte\Template
+{
+	private $file = 'ko';
+
+	public function render()
+	{
+		return strrev($this->file);
+	}
+
+	public function setFile($file)
+	{
+		$this->file = $file;
+	}
+
+	public function getFile()
+	{
+		return $this->file;
+	}
+}
+
+
+$factory = new TemplateFactory(new LatteFactoryMock(new Latte\Engine));
+Assert::type(Template::class, $factory->createTemplate());
+
+
+Assert::exception(function () use ($factory) {
+	$factory->setTemplateClass(TemplateMockWithoutImplement::class);
+}, \Nette\InvalidArgumentException::class, 'Class TemplateMockWithoutImplement does not extend Nette\Bridges\ApplicationLatte\Template or it does not exist.');
+
+
+$factory->setTemplateClass(TemplateMock::class);
+$template = $factory->createTemplate();
+Assert::type(TemplateMock::class, $template);
+Assert::type(UI\ITemplate::class, $template);
+Assert::same([], $template->flashes);
+Assert::same('ok', $template->render());
+$template->setFile('bla');
+Assert::same('alb', $template->render());


### PR DESCRIPTION
With this change it's possible to simply use custom Template implementation. Before this commit Template object initialization was hard-coded into TemplateFactory (related issue: https://github.com/nette/application/issues/141). Usage example (`config.neon`):

```
latte:
    templateClass: App\CustomTemplateImplementation
```

Custom template implementation MUST implement Nette\Application\UI\ITemplate interface.
- feature
- issues - #141
- documentation - probably not needed because this part of framework is not documented (internals)
- BC break - no

This is more request for comments than real PR. Thank you.
