### PR TITLE
RoutingExtension: added support for custom single-route classes.

### DIFF
--- a/src/Bridges/ApplicationDI/RoutingExtension.php
+++ b/src/Bridges/ApplicationDI/RoutingExtension.php
@@ -19,6 +19,7 @@ class RoutingExtension extends Nette\DI\CompilerExtension
 	public $defaults = [
 		'debugger' => NULL,
 		'routes' => [], // of [mask => action]
+		'routeClass' => NULL,
 		'cache' => FALSE,
 	];
 
@@ -26,7 +27,7 @@ class RoutingExtension extends Nette\DI\CompilerExtension
 	private $debugMode;
 
 
-	public function __construct($debugMode = FALSE)
+	public function __construct(bool $debugMode = FALSE)
 	{
 		$this->defaults['debugger'] = interface_exists(Tracy\IBarPanel::class);
 		$this->debugMode = $debugMode;
@@ -42,8 +43,10 @@ class RoutingExtension extends Nette\DI\CompilerExtension
 			->setClass(Nette\Application\IRouter::class)
 			->setFactory(Nette\Application\Routers\RouteList::class);
 
-		foreach ($config['routes'] as $mask => $action) {
-			$router->addSetup('$service[] = new Nette\Application\Routers\Route(?, ?);', [$mask, $action]);
+		$routeClass = $this->config['routeClass'] ?: 'Nette\Application\Routers\Route';
+
+		foreach ($this->config['routes'] as $mask => $action) {
+			$router->addSetup('$service[] = new ' . $routeClass . '(?, ?)', [$mask, $action]);
 		}
 
 		if ($this->name === 'routing') {

--- a/tests/Bridges.DI/RoutingExtension.basic.phpt
+++ b/tests/Bridges.DI/RoutingExtension.basic.phpt
@@ -12,6 +12,10 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
+class Route extends Nette\Application\Routers\Route
+{}
+
+
 test(function () {
 	$loader = new DI\Config\Loader;
 	$config = $loader->load(Tester\FileMock::create('
@@ -23,13 +27,39 @@ test(function () {
 
 	$compiler = new DI\Compiler;
 	$compiler->addExtension('routing', new RoutingExtension(FALSE));
-	$code = $compiler->addConfig($config)->compile();
+	$code = $compiler->addConfig($config)->setClassName('Container_basic')->compile();
 	eval($code);
 
-	$container = new Container;
+	$container = new Container_basic;
 	$router = $container->getService('router');
 	Assert::type(Nette\Application\Routers\RouteList::class, $router);
 	Assert::count(2, $router);
 	Assert::same('index.php', $router[0]->getMask());
 	Assert::same('item/<id>', $router[1]->getMask());
+
+	Assert::type(Nette\Application\Routers\RouteList::class, $router);
+	Assert::type(Nette\Application\Routers\Route::class, $router[0]);
+});
+
+
+test(function () {
+	$loader = new DI\Config\Loader;
+	$config = $loader->load(Tester\FileMock::create('
+	routing:
+		routeClass:
+			Route
+		routes:
+			item/<id>: Homepage:detail
+	', 'neon'));
+
+	$compiler = new DI\Compiler;
+	$compiler->addExtension('routing', new RoutingExtension(FALSE));
+	$code = $compiler->addConfig($config)->setClassName('Container_customRoute')->compile();
+	eval($code);
+
+	$container = new Container_customRoute;
+	$router = $container->getService('router');
+
+	Assert::type(Nette\Application\Routers\RouteList::class, $router);
+	Assert::type(Route::class, $router[0]);
 });


### PR DESCRIPTION
An alternative way to add new Route to RouteList. It moves control over the Route class into the RouteList, so Neon configuration for RoutingExtension can be used by other combination of classes descended from Nette*\RouteList and Nette*\Route.
