### PR TITLE
Application: fixed empty latest request in request to ErrorPresenter when createInitialRequest() failed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 	},
 	"require-dev": {
 		"nette/tester": "~2.0",
+		"nette/bootstrap": "~2.4",
 		"nette/di": "~2.4",
 		"nette/forms": "~2.4",
 		"nette/robot-loader": "~2.4",

--- a/src/Application/exceptions.php
+++ b/src/Application/exceptions.php
@@ -41,12 +41,24 @@ class BadRequestException extends \Exception
 	/** @var int */
 	protected $code = 404;
 
+	/** @var Request|NULL */
+	protected $request;
 
-	public function __construct($message = '', $code = 0, \Exception $previous = NULL)
+
+	public function __construct($message = '', $code = 0, \Exception $previous = NULL, Request $request = NULL)
 	{
 		parent::__construct($message, $code < 200 || $code > 504 ? $this->code : $code, $previous);
+		$this->request = $request;
 	}
 
+
+	/**
+	 * @return Request|NULL
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
 }
 
 

--- a/tests/Application/ErrorPresenter.custom.phpt
+++ b/tests/Application/ErrorPresenter.custom.phpt
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Test: Custom ErrorPresenter
+ */
+
+use Nette\Application;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+define('TEMP_DIR', __DIR__ . '/../tmp/' . lcg_value());
+@mkdir(TEMP_DIR, 0777, TRUE); // @ - base directory may already exist
+register_shutdown_function(function () {
+	Tester\Helpers::purge(TEMP_DIR);
+	rmdir(TEMP_DIR);
+});
+
+
+class TestPresenter extends Application\UI\Presenter
+{
+
+	public function actionDenied()
+	{
+		throw new Application\ForbiddenRequestException();
+	}
+
+
+	public function actionSuccess()
+	{
+		print 'Success';
+		$this->terminate();
+	}
+
+}
+
+
+class ErrorPresenter implements Application\IPresenter
+{
+
+	public function run(Application\Request $request)
+	{
+		$latest = $request->getParameter('request');
+
+		if ($latest) {
+			$output = 'Error: ' . $latest->getPresenterName() . ':' . $latest->getParameter('action');
+			$output.= ' / ' . $request->getParameter('exception')->getCode();
+		} else {
+			$output = 'Error: NULL';
+		}
+
+		return new Application\Responses\TextResponse($output);
+	}
+
+}
+
+
+function testRequest($url) {
+	$configurator = new Nette\Configurator;
+	$configurator->setDebugMode(FALSE);
+	$configurator->setTempDirectory(TEMP_DIR);
+	$container = $configurator->createContainer();
+
+	$router = $container->getService('router');
+	$router[] = new Application\Routers\Route('//www.%domain%/<presenter>/<action>/', [
+		'presenter' => 'Test',
+		'action' => 'default'
+	]);
+
+	$request = new Nette\Http\Request(new Nette\Http\UrlScript($url));
+	$container->addService('httpRequest', $request);
+
+	$application = $container->getByType('Nette\Application\Application');
+	$application->errorPresenter = 'Error';
+
+	ob_start();
+	$application->run();
+	return ob_get_clean();
+}
+
+
+Assert::same('Error: NULL', testRequest('http://aaa.example.com/'));				// no route matches
+Assert::same('Error: Missing:default / 404', testRequest('http://www.example.com/missing/'));	// missing presenter
+Assert::same('Error: Test:default / 404', testRequest('http://www.example.com/'));		// presenter found, template missing
+Assert::same('Error: Test:denied / 403', testRequest('http://www.example.com/test/denied/'));
+
+Assert::same('Success', testRequest('http://www.example.com/test/success/'));			// no error


### PR DESCRIPTION
When `Application::createInitialRequest()` ends with an exception (missing presenter), `Application::processException()` is called before `Application::processRequest()`. This is problem for `processException()` tries to read property `Application::$requests` that is, however, set later by `processRequest()`. So, even if application got request from router, `ErrorPresenter` gots `NULL` instead of that request.

For this one specific case it should be set manually.