### PR TITLE
Route::constructUrl(): split of module and presenter moved before global filter

### DIFF
--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -286,14 +286,6 @@ class Route implements Application\IRouter
 		$presenter = $appRequest->getPresenterName();
 		$params[self::PRESENTER_KEY] = $presenter;
 
-		if (isset($metadata[NULL][self::FILTER_OUT])) {
-			$params = call_user_func($metadata[NULL][self::FILTER_OUT], $params);
-			if ($params === NULL) {
-				return NULL;
-			}
-			$presenter = $params[self::PRESENTER_KEY];
-		}
-
 		if (isset($metadata[self::MODULE_KEY])) { // try split into module and [submodule:]presenter parts
 			$module = $metadata[self::MODULE_KEY];
 			if (isset($module['fixity']) && strncmp($presenter, $module[self::VALUE] . ':', strlen($module[self::VALUE]) + 1) === 0) {
@@ -306,6 +298,13 @@ class Route implements Application\IRouter
 			} else {
 				$params[self::MODULE_KEY] = substr($presenter, 0, $a);
 				$params[self::PRESENTER_KEY] = substr($presenter, $a + 1);
+			}
+		}
+
+		if (isset($metadata[NULL][self::FILTER_OUT])) {
+			$params = call_user_func($metadata[NULL][self::FILTER_OUT], $params);
+			if ($params === NULL) {
+				return NULL;
 			}
 		}
 

--- a/tests/Routers/Route.filter.global.phpt
+++ b/tests/Routers/Route.filter.global.phpt
@@ -41,18 +41,30 @@ testRouteIn($route, '/abc?param=1', 'Abc.in', [
 
 testRouteIn($route, '/cde?param=1');
 
-\Tester\Assert::null(testRouteOut($route, 'Cde'));
+Assert::null(testRouteOut($route, 'Cde'));
 
 
 $route = new Route('<lang>/<presenter>/<action>', [
 	NULL => [
 		Route::FILTER_IN => function (array $arr) {
-			$arr['presenter'] =  substr($arr['presenter'], 0, -2); // App:AbcCs -> App:Abc
+			if ($arr['module'] !== 'App') {
+				return NULL;
+			}
+			if ($arr['presenter'] !== 'AbcCs') {
+				return NULL;
+			}
+			$arr['presenter'] =  substr($arr['presenter'], 0, -2); // AbcCs -> Abc
 			$arr['action'] = substr($arr['action'], 0, -2);
 			return $arr;
 		},
 		Route::FILTER_OUT => function (array $arr) {
-			$arr['presenter'] .= ucfirst($arr['lang']); // App:Abc -> App:AbcCs
+			if ($arr['module'] !== 'App') {
+				return NULL;
+			}
+			if ($arr['presenter'] !== 'Abc') {
+				return NULL;
+			}
+			$arr['presenter'] .= ucfirst($arr['lang']); // Abc -> AbcCs
 			$arr['action'] .= ucfirst($arr['lang']);
 			return $arr;
 		},


### PR DESCRIPTION
I was doing some changes in structure of my application and I have found something what is IMHO bug.

In short: right now, the global input filter gets module and presenter split (like this: [Module: 'Front', Presenter: 'Homepage']) but output filter gets them together as presenter ([Presenter: 'Front:Homepage']).

Wouldn't it be better to unify the behaviour of those two functions to get the params split in both cases?