### PR TITLE
RoutingPanel: fixed whitespaces in routelist

### DIFF
--- a/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
+++ b/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
@@ -25,6 +25,7 @@ use Tracy\Dumper;
 	#tracy-debug .nette-RoutingPanel pre, #tracy-debug .nette-RoutingPanel code {
 		display: inline;
 		background: transparent;
+		white-space: normal;
 	}
 
 </style>


### PR DESCRIPTION
After commit `ec3380b7` in Tracy, routing panel looks ugly. Top image is how it looks now, the second is how it looks like after my change.

![bug](http://oi63.tinypic.com/sp9mjm.jpg)