### PR TITLE
added RejectedRequestException

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -106,7 +106,7 @@ class Application
 	{
 		$request = $this->router->match($this->httpRequest);
 		if (!$request) {
-			throw new BadRequestException('No route for HTTP request.');
+			throw new RejectRequestException('No route for HTTP request.', RejectRequestException::NO_ROUTE);
 		}
 		return $request;
 	}
@@ -123,13 +123,13 @@ class Application
 		$this->onRequest($this, $request);
 
 		if (!$request->isMethod($request::FORWARD) && !strcasecmp($request->getPresenterName(), (string) $this->errorPresenter)) {
-			throw new BadRequestException('Invalid request. Presenter is not achievable.');
+			throw new RejectRequestException('Invalid request. Presenter is not achievable.', RejectRequestException::WRONG_PRESENTER);
 		}
 
 		try {
 			$this->presenter = $this->presenterFactory->createPresenter($request->getPresenterName());
 		} catch (InvalidPresenterException $e) {
-			throw count($this->requests) > 1 ? $e : new BadRequestException($e->getMessage(), 0, $e);
+			throw count($this->requests) > 1 ? $e : new RejectRequestException($e->getMessage(), RejectRequestException::WRONG_PRESENTER, $e);
 		}
 		$this->onPresenter($this, $this->presenter);
 		$response = $this->presenter->run(clone $request);

--- a/src/Application/MicroPresenter.php
+++ b/src/Application/MicroPresenter.php
@@ -83,7 +83,7 @@ final class MicroPresenter implements Application\IPresenter
 		try {
 			$params = Application\UI\ComponentReflection::combineArgs($reflection, $params);
 		} catch (Nette\InvalidArgumentException $e) {
-			$this->error($e->getMessage());
+			throw new Application\RejectRequestException($e->getMessage(), Application\RejectRequestException::WRONG_ARGUMENT);
 		}
 
 		$response = $callback(...array_values($params));

--- a/src/Application/UI/Form.php
+++ b/src/Application/UI/Form.php
@@ -136,7 +136,7 @@ class Form extends Nette\Forms\Form implements ISignalReceiver
 			}
 		} else {
 			$class = get_class($this);
-			throw new BadSignalException("Missing handler for signal '$signal' in $class.");
+			throw new Nette\Application\RejectRequestException("Missing handler for signal '$signal' in $class.", Nette\Application\RejectRequestException::WRONG_SIGNAL);
 		}
 	}
 }

--- a/src/Application/exceptions.php
+++ b/src/Application/exceptions.php
@@ -67,3 +67,33 @@ class ForbiddenRequestException extends BadRequestException
 	/** @var int */
 	protected $code = Http\IResponse::S403_FORBIDDEN;
 }
+
+
+/**
+ * The exception that indicates request rejected by framework.
+ */
+class RejectRequestException extends UI\BadSignalException
+{
+	public const NO_ROUTE = 1;
+	public const WRONG_PRESENTER = 2;
+	public const WRONG_SIGNAL = 3;
+	public const WRONG_ARGUMENT = 4;
+
+	/** @var int */
+	private $reason;
+
+
+	public function __construct($message, $reason, \Exception $previous = null)
+	{
+		parent::__construct($message, Http\IResponse::S404_NOT_FOUND, $previous);
+	}
+
+
+	/**
+	 * @return int
+	 */
+	public function getReason()
+	{
+		return $this->reason;
+	}
+}


### PR DESCRIPTION
- bug fix? yes (discussion https://github.com/nette/application/commit/212ec4301be07d6ead4a09cc935b4d953bd3e602#commitcomment-19783900)
- new feature? yes
- BC break? no

In case that framework rejects request, it throws `RejectedRequestException` instead of `BadRequestException` or `BadSignalException`. The `BadSignalException` should be deprecated in future.

The main reason is to reach finer granularity for BadRequestException exception.

The naming should be discussed. Is better RejectRequestException or Reject**ed**RequestException? What about constants in RejectedRequestException?

ping @JanTvrdik @matej21 
