### PR TITLE
Removed TABs from routing panel

### DIFF
--- a/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
+++ b/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
@@ -62,17 +62,18 @@ use Tracy\Dumper;
 		<td><code title="<?= htmlSpecialChars($router['class'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlSpecialChars(isset($router['mask']) ? $router['mask'] : $router['class'], ENT_NOQUOTES, 'UTF-8') ?></code></td>
 
 		<td>
-			<?php $tmp = '' ?>
-			<?php foreach ($router['defaults'] as $key => $value): ?>
-				<?php $tmp .= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8')
-					. "&nbsp;=&nbsp;"
-					. (
-						is_string($value)
-							? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />'
-							: Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE])
-					)
-				?>
-			<?php endforeach ?>
+			<?php
+				$tmp = '';
+				foreach ($router['defaults'] as $key => $value) {
+					$tmp .= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8')
+						. "&nbsp;=&nbsp;"
+						. (
+							is_string($value)
+								? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />'
+								: Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE])
+						);
+				}
+			?>
 			<code><?= $tmp ?></code>
 			<?php unset($tmp) ?>
 		</td>
@@ -80,36 +81,36 @@ use Tracy\Dumper;
 		<?php if ($hasModule): ?><td><code><?= htmlSpecialChars($router['module'], ENT_NOQUOTES, 'UTF-8') ?></code></td><?php endif ?>
 
 		<td>
-			<?php if ($router['request']): ?>
-				<?php $tmp = '' ?>
-				<?php $params = $router['request']->getParameters(); ?>
-				<?php $tmp .= '<strong>'
-					. (
-						htmlSpecialChars(
-							$router['request']->getPresenterName() . ':' . (
-								isset($params[Presenter::ACTION_KEY])
-									? $params[Presenter::ACTION_KEY]
-									: Presenter::DEFAULT_ACTION
-							),
-							ENT_NOQUOTES,
-							'UTF-8'
-						)
-					) . '</strong><br />'
-				?>
-				<?php unset($params[Presenter::ACTION_KEY]) ?>
-				<?php foreach ($params as $key => $value): ?>
-					<?php $tmp .= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8')
-						. "&nbsp;=&nbsp;"
+			<?php
+				if ($router['request']) {
+					$tmp = '';
+					$params = $router['request']->getParameters();
+					$tmp .= '<strong>'
 						. (
-							is_string($value)
-								? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />'
-								: Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE])
-						)
-					?>
-				<?php endforeach ?>
-				<code><?= $tmp ?></code>
-				<?php unset($tmp) ?>
-			<?php endif ?>
+							htmlSpecialChars(
+								$router['request']->getPresenterName() . ':' . (
+									isset($params[Presenter::ACTION_KEY])
+										? $params[Presenter::ACTION_KEY]
+										: Presenter::DEFAULT_ACTION
+								),
+								ENT_NOQUOTES,
+								'UTF-8'
+							)
+						) . '</strong><br />';
+					unset($params[Presenter::ACTION_KEY]);
+					foreach ($params as $key => $value) {
+						$tmp .= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8')
+							. "&nbsp;=&nbsp;"
+							. (
+								is_string($value)
+									? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />'
+									: Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE])
+							);
+					}
+					echo "<code>$tmp</code>";
+					unset($tmp);
+				}
+			?>
 		</td>
 	</tr>
 	<?php endforeach ?>

--- a/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
+++ b/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
@@ -61,22 +61,56 @@ use Tracy\Dumper;
 
 		<td><code title="<?= htmlSpecialChars($router['class'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlSpecialChars(isset($router['mask']) ? $router['mask'] : $router['class'], ENT_NOQUOTES, 'UTF-8') ?></code></td>
 
-		<td><code>
-		<?php foreach ($router['defaults'] as $key => $value): ?>
-			<?= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8'), "&nbsp;=&nbsp;", is_string($value) ? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />' : Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE]) ?>
-		<?php endforeach ?>
-		</code></td>
+		<td>
+			<?php $tmp = '' ?>
+			<?php foreach ($router['defaults'] as $key => $value): ?>
+				<?php $tmp .= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8')
+					. "&nbsp;=&nbsp;"
+					. (
+						is_string($value)
+							? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />'
+							: Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE])
+					)
+				?>
+			<?php endforeach ?>
+			<code><?= $tmp ?></code>
+			<?php unset($tmp) ?>
+		</td>
 
 		<?php if ($hasModule): ?><td><code><?= htmlSpecialChars($router['module'], ENT_NOQUOTES, 'UTF-8') ?></code></td><?php endif ?>
 
-		<td><?php if ($router['request']): ?><code>
-		<?php $params = $router['request']->getParameters(); ?>
-		<strong><?= htmlSpecialChars($router['request']->getPresenterName() . ':' . (isset($params[Presenter::ACTION_KEY]) ? $params[Presenter::ACTION_KEY] : Presenter::DEFAULT_ACTION), ENT_NOQUOTES, 'UTF-8') ?></strong><br />
-		<?php unset($params[Presenter::ACTION_KEY]) ?>
-		<?php foreach ($params as $key => $value): ?>
-			<?= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8'), "&nbsp;=&nbsp;", is_string($value) ? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />' : Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE]) ?>
-		<?php endforeach ?>
-		</code><?php endif ?></td>
+		<td>
+			<?php if ($router['request']): ?>
+				<?php $tmp = '' ?>
+				<?php $params = $router['request']->getParameters(); ?>
+				<?php $tmp .= '<strong>'
+					. (
+						htmlSpecialChars(
+							$router['request']->getPresenterName() . ':' . (
+								isset($params[Presenter::ACTION_KEY])
+									? $params[Presenter::ACTION_KEY]
+									: Presenter::DEFAULT_ACTION
+							),
+							ENT_NOQUOTES,
+							'UTF-8'
+						)
+					) . '</strong><br />'
+				?>
+				<?php unset($params[Presenter::ACTION_KEY]) ?>
+				<?php foreach ($params as $key => $value): ?>
+					<?php $tmp .= htmlSpecialChars($key, ENT_IGNORE, 'UTF-8')
+						. "&nbsp;=&nbsp;"
+						. (
+							is_string($value)
+								? htmlSpecialChars($value, ENT_IGNORE, 'UTF-8') . '<br />'
+								: Dumper::toHtml($value, [Dumper::COLLAPSE => TRUE, Dumper::LIVE => TRUE])
+						)
+					?>
+				<?php endforeach ?>
+				<code><?= $tmp ?></code>
+				<?php unset($tmp) ?>
+			<?php endif ?>
+		</td>
 	</tr>
 	<?php endforeach ?>
 	</tbody>


### PR DESCRIPTION
- bug fix? **yes**
- new feature? **no**
- BC break? **no**

Because of indentation within the `<code>` tags the Tracy routing panel is rendering TAB characters in data of *Defaults* and *Matched as* columns. Thus making its content full of white space, lengthy and hard to read due to needed scrolling. 

This PR fixes the described issue by rewriting rendering of the problematic `<code>` tags.  
The second commit just removes unnecessary (in my opinion) PHP tags, making given section easier to read.

An finally, even if this PR adds a few code lines, I believe it is for better readability and the rest of the file should be rewritten in the same fashion someday.