### PR TITLE
Presenter: fixed type of $code  in throwing InvalidLinkException

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -784,7 +784,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 			try {
 				$presenterClass = $this->presenterFactory->getPresenterClass($presenter);
 			} catch (Application\InvalidPresenterException $e) {
-				throw new InvalidLinkException($e->getMessage(), NULL, $e);
+				throw new InvalidLinkException($e->getMessage(), 0, $e);
 			}
 		}
 


### PR DESCRIPTION
- bug fix? yes

Code has to be number. With NULL error was thrown with message `Wrong parameters for Nette\Application\UI\InvalidLinkException([string $message [, long $code [, Throwable $previous = NULL]]])`.