### PR TITLE
Presenter: set defaults to $globalParams, fixes foreach over NULL

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -63,7 +63,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 	public $absoluteUrls = FALSE;
 
 	/** @var array */
-	private $globalParams;
+	private $globalParams = [];
 
 	/** @var array */
 	private $globalState;


### PR DESCRIPTION
Breaks on `getGlobalState()`, where is [foreached null](https://github.com/nette/application/blob/d0f19faf7301197049ccd9fa9eda9419e85d9ea5/src/Application/UI/Presenter.php#L1074).


```php
protected function getGlobalState($forClass = NULL): array
{
	$sinces = &$this->globalStateSinces;
	if ($this->globalState === NULL) {
		$state = [];
		// foreach over NULL
		foreach ($this->globalParams as $id => $params) {
			$prefix = $id . self::NAME_SEPARATOR;
			foreach ($params as $key => $val) {
			// ...
```

Ii think t's called in layout resolution in [`$template`](https://github.com/nette/application/blob/d0f19faf7301197049ccd9fa9eda9419e85d9ea5/src/Bridges/ApplicationLatte/TemplateFactory.php#L113) by provider.

```php
if ($control) {
	$template->control = $control;
	$template->presenter = $presenter;

        // here
	$latte->addProvider('uiControl', $control);
	$latte->addProvider('uiPresenter', $presenter);

	// ...
}
```

- bug fix? yes/no   <!-- #issue numbers, if any -->
- new feature? yes/no
- BC break? yes/no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
