### PR TITLE
FileResponse: strict type fix

### DIFF
--- a/src/Application/Responses/FileResponse.php
+++ b/src/Application/Responses/FileResponse.php
@@ -117,7 +117,7 @@ class FileResponse implements Nette\Application\IResponse
 
 		$httpResponse->setHeader('Content-Length', (string) $length);
 		while (!feof($handle) && $length > 0) {
-			echo $s = fread($handle, min(4e6, $length));
+			echo $s = fread($handle, min(4000000, $length));
 			$length -= strlen($s);
 		}
 		fclose($handle);

--- a/tests/Responses/FileResponse.full.phpt
+++ b/tests/Responses/FileResponse.full.phpt
@@ -14,6 +14,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
+/* A small file */
 test(function () {
 	$file = __FILE__;
 	$fileResponse = new FileResponse($file);
@@ -22,4 +23,23 @@ test(function () {
 	ob_start();
 	$fileResponse->send(new Http\Request(new Http\UrlScript), new Http\Response);
 	Assert::same($origData, ob_get_clean());
+});
+
+/* A big file */
+test(function () {
+	$file = Tester\FileMock::create();
+
+	$data = '';
+	for ($i = 0; $i < 20000; $i++) {
+		$data .= 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi efficitur nisl mauris, ' .
+			'sed bibendum leo tempor ornare. Etiam sodales enim sem. Proin lobortis metus at sagittis ' .
+			'imperdiet. In non fringilla libero, ac porta purus. Nam gravida quis tellus quis semper.';
+	}
+
+	file_put_contents($file, $data);
+	$fileResponse = new FileResponse($file);
+
+	ob_start();
+	$fileResponse->send(new Http\Request(new Http\UrlScript), new Http\Response);
+	Assert::same($data, ob_get_clean());
 });


### PR DESCRIPTION
Since `4e6` is float and function `fread()` exects integer value for
length, it caused a `TypeError` on bigger files.

- bug fix? yes
- BC break? no
