### PR TITLE
TemplateFactory: retrieve CSP nonce from CSP-Report-Only header as a …

### DIFF
--- a/src/Bridges/ApplicationLatte/TemplateFactory.php
+++ b/src/Bridges/ApplicationLatte/TemplateFactory.php
@@ -112,7 +112,11 @@ class TemplateFactory implements UI\ITemplateFactory
 			$latte->addProvider('uiControl', $control);
 			$latte->addProvider('uiPresenter', $presenter);
 			$latte->addProvider('snippetBridge', new Nette\Bridges\ApplicationLatte\SnippetBridge($control));
-			$nonce = $presenter && preg_match('#\s\'nonce-([\w+/]+=*)\'#', (string) $presenter->getHttpResponse()->getHeader('Content-Security-Policy'), $m) ? $m[1] : null;
+			$header = $presenter ? $presenter->getHttpResponse()->getHeader('Content-Security-Policy') : false;
+			if ($header === null) {
+				$header = $presenter->getHttpResponse()->getHeader('Content-Security-Policy-Report-Only');
+			}
+			$nonce = preg_match('#\s\'nonce-([\w+/]+=*)\'#', (string) $header, $m) ? $m[1] : null;
 			$latte->addProvider('uiNonce', $nonce);
 		}
 		$latte->addProvider('cacheStorage', $this->cacheStorage);


### PR DESCRIPTION
…fallback, related https://github.com/nette/http/pull/135

- bug fix? no
- new feature? yes
- BC break? no
- doc PR: will do if accepted

This is just mandatory change related to https://github.com/nette/http/pull/135. Nonce is retrieved from CSP-Report-Only if not found in CSP header.
