### PR TITLE
Add getter for httpRequest to application

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -198,6 +198,15 @@ class Application
 
 
 	/**
+	 * Returns HTTP request.
+	 */
+	public function getHttpRequest(): Nette\Http\IRequest
+	{
+		return $this->httpRequest;
+	}
+
+
+	/**
 	 * Returns presenter factory.
 	 */
 	public function getPresenterFactory(): IPresenterFactory


### PR DESCRIPTION
- new feature
- BC break: no
- doc PR: not needed

Sometimes I need to work with Nette\Http\IRequest inside an event (mainly onStartup), but there is a getter missing, so I have to do it like that:

```php
$reflectionClass = new \ReflectionClass(Application::class);
$httpRequestProperty = $reflectionClass->getProperty('httpRequest');
$httpRequestProperty->setAccessible(true);

$httpRequest = $httpRequestProperty->getValue();
```


