### PR TITLE
Separated routing to nette/routing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
 		"php": ">=7.1",
 		"nette/component-model": "^3.0.0-RC1",
 		"nette/http": "^3.0",
+		"nette/routing": "~3.0.0",
 		"nette/utils": "^3.0"
 	},
 	"suggest": {

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Nette\Application;
 
 use Nette;
+use Nette\Routing\Router;
 
 
 /**
@@ -61,11 +62,11 @@ class Application
 	/** @var IPresenterFactory */
 	private $presenterFactory;
 
-	/** @var IRouter */
+	/** @var Router */
 	private $router;
 
 
-	public function __construct(IPresenterFactory $presenterFactory, IRouter $router, Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse)
+	public function __construct(IPresenterFactory $presenterFactory, Router $router, Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse)
 	{
 		$this->httpRequest = $httpRequest;
 		$this->httpResponse = $httpResponse;
@@ -204,7 +205,7 @@ class Application
 	/**
 	 * Returns router.
 	 */
-	public function getRouter(): IRouter
+	public function getRouter(): Router
 	{
 		return $this->router;
 	}

--- a/src/Application/IRouter.php
+++ b/src/Application/IRouter.php
@@ -13,20 +13,8 @@ use Nette;
 
 
 /**
- * The bi-directional router.
+ * @deprecated use Nette\Routing\Router
  */
-interface IRouter
+interface IRouter extends Nette\Routing\Router
 {
-	/** only matching route */
-	public const ONE_WAY = 0b0001;
-
-	/**
-	 * Maps HTTP request to an array.
-	 */
-	function match(Nette\Http\IRequest $httpRequest): ?array;
-
-	/**
-	 * Constructs absolute URL from array.
-	 */
-	function constructUrl(array $params, Nette\Http\UrlScript $refUrl): ?string;
 }

--- a/src/Application/LinkGenerator.php
+++ b/src/Application/LinkGenerator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Nette\Application;
 
 use Nette;
+use Nette\Routing\Router;
 
 
 /**
@@ -19,7 +20,7 @@ final class LinkGenerator
 {
 	use Nette\SmartObject;
 
-	/** @var IRouter */
+	/** @var Router */
 	private $router;
 
 	/** @var Nette\Http\UrlScript */
@@ -29,7 +30,7 @@ final class LinkGenerator
 	private $presenterFactory;
 
 
-	public function __construct(IRouter $router, Nette\Http\UrlScript $refUrl, IPresenterFactory $presenterFactory = null)
+	public function __construct(Router $router, Nette\Http\UrlScript $refUrl, IPresenterFactory $presenterFactory = null)
 	{
 		$this->router = $router;
 		$this->refUrl = $refUrl;

--- a/src/Application/MicroPresenter.php
+++ b/src/Application/MicroPresenter.php
@@ -14,6 +14,7 @@ use Nette;
 use Nette\Application;
 use Nette\Application\Responses;
 use Nette\Http;
+use Nette\Routing\Router;
 
 
 /**
@@ -29,14 +30,14 @@ final class MicroPresenter implements Application\IPresenter
 	/** @var Nette\Http\IRequest|null */
 	private $httpRequest;
 
-	/** @var Application\IRouter|null */
+	/** @var Router|null */
 	private $router;
 
 	/** @var Application\Request|null */
 	private $request;
 
 
-	public function __construct(Nette\DI\Container $context = null, Http\IRequest $httpRequest = null, Application\IRouter $router = null)
+	public function __construct(Nette\DI\Container $context = null, Http\IRequest $httpRequest = null, Router $router = null)
 	{
 		$this->context = $context;
 		$this->httpRequest = $httpRequest;

--- a/src/Application/Routers/Route.php
+++ b/src/Application/Routers/Route.php
@@ -10,58 +10,19 @@ declare(strict_types=1);
 namespace Nette\Application\Routers;
 
 use Nette;
-use Nette\Application;
-use Nette\Utils\Strings;
 
 
 /**
  * The bidirectional route is responsible for mapping
  * HTTP request to an array for dispatch and vice-versa.
  */
-class Route implements Application\IRouter
+class Route extends Nette\Routing\Route implements Nette\Application\IRouter
 {
-	use Nette\SmartObject;
-
-	/** key used in metadata {@link Route::__construct} */
-	public const
-		VALUE = 'value',
-		PATTERN = 'pattern',
-		FILTER_IN = 'filterIn',
-		FILTER_OUT = 'filterOut',
-		FILTER_TABLE = 'filterTable',
-		FILTER_STRICT = 'filterStrict';
-
-	/** key used in metadata */
-	private const
-		DEFAULT = 'defOut',
-		FIXITY = 'fixity',
-		FILTER_TABLE_OUT = 'filterTO';
-
-	/** url type */
-	private const
-		HOST = 1,
-		PATH = 2,
-		RELATIVE = 3;
-
-	/** fixity types - how to handle default value? {@link Route::$metadata} */
-	private const
-		OPTIONAL = 0,
-		PATH_OPTIONAL = 1,
-		CONSTANT = 2;
-
 	private const
 		PRESENTER_KEY = 'presenter',
 		MODULE_KEY = 'module';
 
-	/** @deprecated */
-	public static $styles = [];
-
-	/** @var array */
-	protected $defaultMeta = [
-		'#' => [ // default style for path parameters
-			self::PATTERN => '[^/]+',
-			self::FILTER_OUT => [__CLASS__, 'param2path'],
-		],
+	private const UI_META = [
 		'module' => [
 			self::PATTERN => '[a-z][a-z0-9.-]*',
 			self::FILTER_IN => [__CLASS__, 'path2presenter'],
@@ -79,38 +40,11 @@ class Route implements Application\IRouter
 		],
 	];
 
-	/** @var string */
-	private $mask;
-
-	/** @var array */
-	private $sequence;
-
-	/** @var string  regular expression pattern */
-	private $re;
-
-	/** @var string[]  parameter aliases in regular expression */
-	private $aliases;
-
-	/** @var array of [value & fixity, filterIn, filterOut] */
-	private $metadata = [];
-
-	/** @var array  */
-	private $xlat;
-
-	/** @var int HOST, PATH, RELATIVE */
-	private $type;
-
-	/** @var string  http | https */
-	private $scheme;
+	/** @deprecated */
+	public static $styles = [];
 
 	/** @var int */
 	private $flags;
-
-	/** @var Nette\Http\Url */
-	private $lastRefUrl;
-
-	/** @var string */
-	private $lastBaseUrl;
 
 
 	/**
@@ -135,13 +69,14 @@ class Route implements Application\IRouter
 			];
 		}
 
+		$this->defaultMeta = $this->defaultMeta + self::UI_META;
 		if (self::$styles) {
 			trigger_error('Route::$styles is deprecated.', E_USER_DEPRECATED);
 			array_replace_recursive($this->defaultMeta, self::$styles);
 		}
 
 		$this->flags = $flags;
-		$this->setMask($mask, $metadata);
+		parent::__construct($mask, $metadata);
 	}
 
 
@@ -150,103 +85,19 @@ class Route implements Application\IRouter
 	 */
 	public function match(Nette\Http\IRequest $httpRequest): ?array
 	{
-		// combine with precedence: mask (params in URL-path), fixity, query, (post,) defaults
+		$params = parent::match($httpRequest);
 
-		// 1) URL MASK
-		$url = $httpRequest->getUrl();
-		$re = $this->re;
-
-		if ($this->type === self::HOST) {
-			$host = $url->getHost();
-			$path = '//' . $host . $url->getPath();
-			$parts = ip2long($host) ? [$host] : array_reverse(explode('.', $host));
-			$re = strtr($re, [
-				'/%basePath%/' => preg_quote($url->getBasePath(), '#'),
-				'%tld%' => preg_quote($parts[0], '#'),
-				'%domain%' => preg_quote(isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0], '#'),
-				'%sld%' => preg_quote($parts[1] ?? '', '#'),
-				'%host%' => preg_quote($host, '#'),
-			]);
-
-		} elseif ($this->type === self::RELATIVE) {
-			$basePath = $url->getBasePath();
-			if (strncmp($url->getPath(), $basePath, strlen($basePath)) !== 0) {
-				return null;
-			}
-			$path = substr($url->getPath(), strlen($basePath));
-
-		} else {
-			$path = $url->getPath();
-		}
-
-		if ($path !== '') {
-			$path = rtrim(rawurldecode($path), '/') . '/';
-		}
-
-		if (!$matches = Strings::match($path, $re)) {
-			// stop, not matched
+		if ($params === null) {
+			return null;
+		} elseif (!isset($params[self::PRESENTER_KEY])) {
+			throw new Nette\InvalidStateException('Missing presenter in route definition.');
+		} elseif (!is_string($params[self::PRESENTER_KEY])) {
 			return null;
 		}
 
-		// assigns matched values to parameters
-		$params = [];
-		foreach ($matches as $k => $v) {
-			if (is_string($k) && $v !== '') {
-				$params[$this->aliases[$k]] = $v;
-			}
-		}
-
-
-		// 2) CONSTANT FIXITY
-		foreach ($this->metadata as $name => $meta) {
-			if (!isset($params[$name]) && isset($meta[self::FIXITY]) && $meta[self::FIXITY] !== self::OPTIONAL) {
-				$params[$name] = null; // cannot be overwriten in 3) and detected by isset() in 4)
-			}
-		}
-
-
-		// 3) QUERY
-		if ($this->xlat) {
-			$params += self::renameKeys($httpRequest->getQuery(), array_flip($this->xlat));
-		} else {
-			$params += $httpRequest->getQuery();
-		}
-
-
-		// 4) APPLY FILTERS & FIXITY
-		foreach ($this->metadata as $name => $meta) {
-			if (isset($params[$name])) {
-				if (!is_scalar($params[$name])) {
-					// do nothing
-				} elseif (isset($meta[self::FILTER_TABLE][$params[$name]])) { // applies filterTable only to scalar parameters
-					$params[$name] = $meta[self::FILTER_TABLE][$params[$name]];
-
-				} elseif (isset($meta[self::FILTER_TABLE]) && !empty($meta[self::FILTER_STRICT])) {
-					return null; // rejected by filterTable
-
-				} elseif (isset($meta[self::FILTER_IN])) { // applies filterIn only to scalar parameters
-					$params[$name] = $meta[self::FILTER_IN]((string) $params[$name]);
-					if ($params[$name] === null && !isset($meta[self::FIXITY])) {
-						return null; // rejected by filter
-					}
-				}
-
-			} elseif (isset($meta[self::FIXITY])) {
-				$params[$name] = $meta[self::VALUE];
-			}
-		}
-
-		if (isset($this->metadata[null][self::FILTER_IN])) {
-			$params = $this->metadata[null][self::FILTER_IN]($params);
-			if ($params === null) {
-				return null;
-			}
-		}
-
-		// 5) PARAMETER MODULE
 		$presenter = $params[self::PRESENTER_KEY] ?? null;
-		if (isset($this->metadata[self::MODULE_KEY], $params[self::MODULE_KEY]) && is_string($presenter)) {
-			$params[self::PRESENTER_KEY] = $params[self::MODULE_KEY] . ':' . $presenter;
+		if (isset($this->getMetadata()[self::MODULE_KEY], $params[self::MODULE_KEY]) && is_string($presenter)) {
+			$params[self::PRESENTER_KEY] = $params[self::MODULE_KEY] . ':' . $params[self::PRESENTER_KEY];
 		}
 		unset($params[self::MODULE_KEY]);
 
@@ -263,12 +114,11 @@ class Route implements Application\IRouter
 			return null;
 		}
 
-		$metadata = $this->metadata;
-		$presenter = $params[self::PRESENTER_KEY];
-
+		$metadata = $this->getMetadata();
 		if (isset($metadata[self::MODULE_KEY])) { // try split into module and [submodule:]presenter parts
+			$presenter = $params[self::PRESENTER_KEY];
 			$module = $metadata[self::MODULE_KEY];
-			if (isset($module[self::FIXITY], $module[self::VALUE]) && strncmp($presenter, $module[self::VALUE] . ':', strlen($module[self::VALUE]) + 1) === 0) {
+			if (isset($module['fixity'], $module[self::VALUE]) && strncmp($presenter, $module[self::VALUE] . ':', strlen($module[self::VALUE]) + 1) === 0) {
 				$a = strlen($module[self::VALUE]);
 			} else {
 				$a = strrpos($presenter, ':');
@@ -281,327 +131,7 @@ class Route implements Application\IRouter
 			}
 		}
 
-		if (isset($metadata[null][self::FILTER_OUT])) {
-			$params = $metadata[null][self::FILTER_OUT]($params);
-			if ($params === null) {
-				return null;
-			}
-		}
-
-		foreach ($metadata as $name => $meta) {
-			if (!isset($params[$name])) {
-				continue; // retains null values
-			}
-
-			if (is_scalar($params[$name])) {
-				$params[$name] = $params[$name] === false ? '0' : (string) $params[$name];
-			}
-
-			if (isset($meta[self::FIXITY])) {
-				if ($params[$name] === $meta[self::VALUE]) { // remove default values; null values are retain
-					unset($params[$name]);
-					continue;
-
-				} elseif ($meta[self::FIXITY] === self::CONSTANT) {
-					return null; // missing or wrong parameter '$name'
-				}
-			}
-
-			if (is_scalar($params[$name]) && isset($meta[self::FILTER_TABLE_OUT][$params[$name]])) {
-				$params[$name] = $meta[self::FILTER_TABLE_OUT][$params[$name]];
-
-			} elseif (isset($meta[self::FILTER_TABLE_OUT]) && !empty($meta[self::FILTER_STRICT])) {
-				return null;
-
-			} elseif (isset($meta[self::FILTER_OUT])) {
-				$params[$name] = $meta[self::FILTER_OUT]($params[$name]);
-			}
-
-			if (isset($meta[self::PATTERN]) && !preg_match("#(?:{$meta[self::PATTERN]})\\z#A", rawurldecode((string) $params[$name]))) {
-				return null; // pattern not match
-			}
-		}
-
-		// compositing path
-		$sequence = $this->sequence;
-		$brackets = [];
-		$required = null; // null for auto-optional
-		$url = '';
-		$i = count($sequence) - 1;
-		do {
-			$url = $sequence[$i] . $url;
-			if ($i === 0) {
-				break;
-			}
-			$i--;
-
-			$name = $sequence[$i--]; // parameter name
-
-			if ($name === ']') { // opening optional part
-				$brackets[] = $url;
-
-			} elseif ($name[0] === '[') { // closing optional part
-				$tmp = array_pop($brackets);
-				if ($required < count($brackets) + 1) { // is this level optional?
-					if ($name !== '[!') { // and not "required"-optional
-						$url = $tmp;
-					}
-				} else {
-					$required = count($brackets);
-				}
-
-			} elseif ($name[0] === '?') { // "foo" parameter
-				continue;
-
-			} elseif (isset($params[$name]) && $params[$name] != '') { // intentionally ==
-				$required = count($brackets); // make this level required
-				$url = $params[$name] . $url;
-				unset($params[$name]);
-
-			} elseif (isset($metadata[$name][self::FIXITY])) { // has default value?
-				if ($required === null && !$brackets) { // auto-optional
-					$url = '';
-				} else {
-					$url = $metadata[$name][self::DEFAULT] . $url;
-				}
-
-			} else {
-				return null; // missing parameter '$name'
-			}
-		} while (true);
-
-		$scheme = $this->scheme ?: $refUrl->getScheme();
-
-		if ($this->type === self::HOST) {
-			$host = $refUrl->getHost();
-			$parts = ip2long($host) ? [$host] : array_reverse(explode('.', $host));
-			$url = strtr($url, [
-				'/%basePath%/' => $refUrl->getBasePath(),
-				'%tld%' => $parts[0],
-				'%domain%' => isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0],
-				'%sld%' => $parts[1] ?? '',
-				'%host%' => $host,
-			]);
-			$url = $scheme . ':' . $url;
-		} else {
-			if ($this->lastRefUrl !== $refUrl) {
-				$basePath = ($this->type === self::RELATIVE ? $refUrl->getBasePath() : '');
-				$this->lastBaseUrl = $scheme . '://' . $refUrl->getAuthority() . $basePath;
-				$this->lastRefUrl = $refUrl;
-			}
-			$url = $this->lastBaseUrl . $url;
-		}
-
-		if (strpos($url, '//', strlen($scheme) + 3) !== false) {
-			return null;
-		}
-
-		// build query string
-		if ($this->xlat) {
-			$params = self::renameKeys($params, $this->xlat);
-		}
-
-		$sep = ini_get('arg_separator.input');
-		$query = http_build_query($params, '', $sep ? $sep[0] : '&');
-		if ($query != '') { // intentionally ==
-			$url .= '?' . $query;
-		}
-
-		return $url;
-	}
-
-
-	/**
-	 * Parse mask and array of default values; initializes object.
-	 */
-	private function setMask(string $mask, array $metadata): void
-	{
-		$this->mask = $mask;
-
-		// detect '//host/path' vs. '/abs. path' vs. 'relative path'
-		if (preg_match('#(?:(https?):)?(//.*)#A', $mask, $m)) {
-			$this->type = self::HOST;
-			[, $this->scheme, $mask] = $m;
-
-		} elseif (substr($mask, 0, 1) === '/') {
-			$this->type = self::PATH;
-
-		} else {
-			$this->type = self::RELATIVE;
-		}
-
-		foreach ($metadata as $name => $meta) {
-			if (!is_array($meta)) {
-				$metadata[$name] = $meta = [self::VALUE => $meta];
-			}
-
-			if (array_key_exists(self::VALUE, $meta)) {
-				if (is_scalar($meta[self::VALUE])) {
-					$metadata[$name][self::VALUE] = $meta[self::VALUE] === false ? '0' : (string) $meta[self::VALUE];
-				}
-				$metadata[$name]['fixity'] = self::CONSTANT;
-			}
-		}
-
-		if (strpbrk($mask, '?<>[]') === false) {
-			$this->re = '#' . preg_quote($mask, '#') . '/?\z#A';
-			$this->sequence = [$mask];
-			$this->metadata = $metadata;
-			return;
-		}
-
-		// PARSE MASK
-		// <parameter-name[=default] [pattern]> or [ or ] or ?...
-		$parts = Strings::split($mask, '/<([^<>= ]+)(=[^<> ]*)? *([^<>]*)>|(\[!?|\]|\s*\?.*)/');
-
-		$this->xlat = [];
-		$i = count($parts) - 1;
-
-		// PARSE QUERY PART OF MASK
-		if (isset($parts[$i - 1]) && substr(ltrim($parts[$i - 1]), 0, 1) === '?') {
-			// name=<parameter-name [pattern]>
-			$matches = Strings::matchAll($parts[$i - 1], '/(?:([a-zA-Z0-9_.-]+)=)?<([^> ]+) *([^>]*)>/');
-
-			foreach ($matches as [, $param, $name, $pattern]) { // $pattern is not used
-				$meta = ($metadata[$name] ?? []) + ($this->defaultMeta['?' . $name] ?? []);
-
-				if (array_key_exists(self::VALUE, $meta)) {
-					$meta[self::FIXITY] = self::OPTIONAL;
-				}
-
-				unset($meta[self::PATTERN]);
-				$meta[self::FILTER_TABLE_OUT] = empty($meta[self::FILTER_TABLE]) ? null : array_flip($meta[self::FILTER_TABLE]);
-
-				$metadata[$name] = $meta;
-				if ($param !== '') {
-					$this->xlat[$name] = $param;
-				}
-			}
-			$i -= 5;
-		}
-
-		// PARSE PATH PART OF MASK
-		$brackets = 0; // optional level
-		$re = '';
-		$sequence = [];
-		$autoOptional = true;
-		$aliases = [];
-		do {
-			$part = $parts[$i]; // part of path
-			if (strpbrk($part, '<>') !== false) {
-				throw new Nette\InvalidArgumentException("Unexpected '$part' in mask '$mask'.");
-			}
-			array_unshift($sequence, $part);
-			$re = preg_quote($part, '#') . $re;
-			if ($i === 0) {
-				break;
-			}
-			$i--;
-
-			$part = $parts[$i]; // [ or ]
-			if ($part === '[' || $part === ']' || $part === '[!') {
-				$brackets += $part[0] === '[' ? -1 : 1;
-				if ($brackets < 0) {
-					throw new Nette\InvalidArgumentException("Unexpected '$part' in mask '$mask'.");
-				}
-				array_unshift($sequence, $part);
-				$re = ($part[0] === '[' ? '(?:' : ')?') . $re;
-				$i -= 4;
-				continue;
-			}
-
-			$pattern = trim($parts[$i--]); // validation condition (as regexp)
-			$default = $parts[$i--]; // default value
-			$name = $parts[$i--]; // parameter name
-			array_unshift($sequence, $name);
-
-			if ($name[0] === '?') { // "foo" parameter
-				$name = substr($name, 1);
-				$re = $pattern ? '(?:' . preg_quote($name, '#') . "|$pattern)$re" : preg_quote($name, '#') . $re;
-				$sequence[1] = $name . $sequence[1];
-				continue;
-			}
-
-			// pattern, condition & metadata
-			$meta = ($metadata[$name] ?? []) + ($this->defaultMeta[$name] ?? $this->defaultMeta['#']);
-
-			if ($pattern == '' && isset($meta[self::PATTERN])) {
-				$pattern = $meta[self::PATTERN];
-			}
-
-			if ($default !== '') {
-				$meta[self::VALUE] = substr($default, 1);
-				$meta[self::FIXITY] = self::PATH_OPTIONAL;
-			}
-
-			$meta[self::FILTER_TABLE_OUT] = empty($meta[self::FILTER_TABLE]) ? null : array_flip($meta[self::FILTER_TABLE]);
-			if (array_key_exists(self::VALUE, $meta)) {
-				if (isset($meta[self::FILTER_TABLE_OUT][$meta[self::VALUE]])) {
-					$meta[self::DEFAULT] = $meta[self::FILTER_TABLE_OUT][$meta[self::VALUE]];
-
-				} elseif (isset($meta[self::VALUE], $meta[self::FILTER_OUT])) {
-					$meta[self::DEFAULT] = $meta[self::FILTER_OUT]($meta[self::VALUE]);
-
-				} else {
-					$meta[self::DEFAULT] = $meta[self::VALUE];
-				}
-			}
-			$meta[self::PATTERN] = $pattern;
-
-			// include in expression
-			$aliases['p' . $i] = $name;
-			$re = '(?P<p' . $i . '>(?U)' . $pattern . ')' . $re;
-			if ($brackets) { // is in brackets?
-				if (!isset($meta[self::VALUE])) {
-					$meta[self::VALUE] = $meta[self::DEFAULT] = null;
-				}
-				$meta[self::FIXITY] = self::PATH_OPTIONAL;
-
-			} elseif (isset($meta[self::FIXITY])) {
-				if ($autoOptional) {
-					$re = '(?:' . $re . ')?';
-				}
-				$meta[self::FIXITY] = self::PATH_OPTIONAL;
-
-			} else {
-				$autoOptional = false;
-			}
-
-			$metadata[$name] = $meta;
-		} while (true);
-
-		if ($brackets) {
-			throw new Nette\InvalidArgumentException("Missing '[' in mask '$mask'.");
-		}
-
-		$this->aliases = $aliases;
-		$this->re = '#' . $re . '/?\z#A';
-		$this->metadata = $metadata;
-		$this->sequence = $sequence;
-	}
-
-
-	/**
-	 * Returns mask.
-	 */
-	public function getMask(): string
-	{
-		return $this->mask;
-	}
-
-
-	/**
-	 * Returns default values.
-	 */
-	public function getDefaults(): array
-	{
-		$defaults = [];
-		foreach ($this->metadata as $name => $meta) {
-			if (isset($meta[self::FIXITY])) {
-				$defaults[$name] = $meta[self::VALUE];
-			}
-		}
-		return $defaults;
+		return parent::constructUrl($params, $refUrl);
 	}
 
 
@@ -611,61 +141,6 @@ class Route implements Application\IRouter
 	public function getFlags(): int
 	{
 		return $this->flags;
-	}
-
-
-	/********************* Utilities ****************d*g**/
-
-
-	/**
-	 * Proprietary cache aim.
-	 * @internal
-	 * @return string[]|null
-	 */
-	public function getTargetPresenters(): ?array
-	{
-		if ($this->flags & self::ONE_WAY) {
-			return [];
-		}
-
-		$m = $this->metadata;
-		$module = '';
-
-		if (isset($m[self::MODULE_KEY])) {
-			if (($m[self::MODULE_KEY][self::FIXITY] ?? null) === self::CONSTANT) {
-				$module = $m[self::MODULE_KEY][self::VALUE] . ':';
-			} else {
-				return null;
-			}
-		}
-
-		if (($m[self::PRESENTER_KEY][self::FIXITY] ?? null) === self::CONSTANT) {
-			return [$module . $m[self::PRESENTER_KEY][self::VALUE]];
-		}
-		return null;
-	}
-
-
-	/**
-	 * Rename keys in array.
-	 */
-	private static function renameKeys(array $arr, array $xlat): array
-	{
-		if (empty($xlat)) {
-			return $arr;
-		}
-
-		$res = [];
-		$occupied = array_flip($xlat);
-		foreach ($arr as $k => $v) {
-			if (isset($xlat[$k])) {
-				$res[$xlat[$k]] = $v;
-
-			} elseif (!isset($occupied[$k])) {
-				$res[$k] = $v;
-			}
-		}
-		return $res;
 	}
 
 
@@ -719,14 +194,5 @@ class Route implements Application\IRouter
 		$s = str_replace('. ', ':', $s);
 		$s = str_replace('- ', '', $s);
 		return $s;
-	}
-
-
-	/**
-	 * Url encode.
-	 */
-	public static function param2path(string $s): string
-	{
-		return str_replace('%2F', '/', rawurlencode($s));
 	}
 }

--- a/src/Application/Routers/RouteList.php
+++ b/src/Application/Routers/RouteList.php
@@ -62,6 +62,31 @@ class RouteList extends Nette\Routing\RouteList implements Nette\Application\IRo
 	}
 
 
+	/**
+	 * @param  string  $mask  e.g. '<presenter>/<action>/<id \d{1,3}>'
+	 * @param  array|string|\Closure  $metadata  default values or metadata or callback for NetteModule\MicroPresenter
+	 * @return static
+	 */
+	public function addRoute(string $mask, $metadata = [], int $flags = 0)
+	{
+		$this->add(new Route($mask, $metadata), $flags);
+		return $this;
+	}
+
+
+	/**
+	 * @return static
+	 */
+	public function withModule(string $module)
+	{
+		$router = new static;
+		$router->module = $module . ':';
+		$router->parent = $this;
+		$this->add($router);
+		return $router;
+	}
+
+
 	public function getModule(): ?string
 	{
 		return $this->module;

--- a/src/Application/Routers/SimpleRouter.php
+++ b/src/Application/Routers/SimpleRouter.php
@@ -16,19 +16,14 @@ use Nette\Application;
 /**
  * The bidirectional route for trivial routing via query parameters.
  */
-final class SimpleRouter implements Application\IRouter
+final class SimpleRouter extends Nette\Routing\SimpleRouter implements Nette\Application\IRouter
 {
-	use Nette\SmartObject;
-
 	private const
 		PRESENTER_KEY = 'presenter',
 		MODULE_KEY = 'module';
 
 	/** @var string */
 	private $module = '';
-
-	/** @var array */
-	private $defaults;
 
 	/** @var int */
 	private $flags;
@@ -52,8 +47,8 @@ final class SimpleRouter implements Application\IRouter
 			unset($defaults[self::MODULE_KEY]);
 		}
 
-		$this->defaults = $defaults;
 		$this->flags = $flags;
+		parent::__construct($defaults);
 	}
 
 
@@ -62,13 +57,7 @@ final class SimpleRouter implements Application\IRouter
 	 */
 	public function match(Nette\Http\IRequest $httpRequest): ?array
 	{
-		if ($httpRequest->getUrl()->getPathInfo() !== '') {
-			return null;
-		}
-		// combine with precedence: get, (post,) defaults
-		$params = $httpRequest->getQuery();
-		$params += $this->defaults;
-
+		$params = parent::match($httpRequest);
 		$presenter = $params[self::PRESENTER_KEY] ?? null;
 		if (is_string($presenter)) {
 			$params[self::PRESENTER_KEY] = $this->module . $presenter;
@@ -87,36 +76,11 @@ final class SimpleRouter implements Application\IRouter
 			return null;
 		}
 
-		// presenter name
-		if (strncmp($params[self::PRESENTER_KEY], $this->module, strlen($this->module)) === 0) {
-			$params[self::PRESENTER_KEY] = substr($params[self::PRESENTER_KEY], strlen($this->module));
-		} else {
+		if (strncmp($params[self::PRESENTER_KEY], $this->module, strlen($this->module)) !== 0) {
 			return null;
 		}
-
-		// remove default values; null values are retain
-		foreach ($this->defaults as $key => $value) {
-			if (isset($params[$key]) && $params[$key] == $value) { // intentionally ==
-				unset($params[$key]);
-			}
-		}
-
-		$url = $refUrl->getScheme() . '://' . $refUrl->getAuthority() . $refUrl->getPath();
-		$sep = ini_get('arg_separator.input');
-		$query = http_build_query($params, '', $sep ? $sep[0] : '&');
-		if ($query != '') { // intentionally ==
-			$url .= '?' . $query;
-		}
-		return $url;
-	}
-
-
-	/**
-	 * Returns default values.
-	 */
-	public function getDefaults(): array
-	{
-		return $this->defaults;
+		$params[self::PRESENTER_KEY] = substr($params[self::PRESENTER_KEY], strlen($this->module));
+		return parent::constructUrl($params, $refUrl);
 	}
 
 

--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -120,7 +120,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 	/** @var Nette\Application\IPresenterFactory */
 	private $presenterFactory;
 
-	/** @var Nette\Application\IRouter */
+	/** @var Nette\Routing\Router */
 	private $router;
 
 	/** @var Nette\Security\User */
@@ -1264,7 +1264,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 	/********************* services ****************d*g**/
 
 
-	final public function injectPrimary(Nette\DI\Container $context = null, Application\IPresenterFactory $presenterFactory = null, Application\IRouter $router = null,
+	final public function injectPrimary(Nette\DI\Container $context = null, Application\IPresenterFactory $presenterFactory = null, Nette\Routing\Router $router = null,
 		Http\IRequest $httpRequest, Http\IResponse $httpResponse, Http\Session $session = null, Nette\Security\User $user = null, ITemplateFactory $templateFactory = null)
 	{
 		if ($this->presenterFactory !== null) {

--- a/src/Bridges/ApplicationDI/RoutingExtension.php
+++ b/src/Bridges/ApplicationDI/RoutingExtension.php
@@ -42,7 +42,7 @@ final class RoutingExtension extends Nette\DI\CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		$router = $builder->addDefinition($this->prefix('router'))
-			->setType(Nette\Application\IRouter::class)
+			->setType(Nette\Routing\Router::class)
 			->setFactory(Nette\Application\Routers\RouteList::class)
 			->setExported();
 

--- a/src/Bridges/ApplicationTracy/RoutingPanel.php
+++ b/src/Bridges/ApplicationTracy/RoutingPanel.php
@@ -23,7 +23,7 @@ final class RoutingPanel implements Tracy\IBarPanel
 {
 	use Nette\SmartObject;
 
-	/** @var Nette\Application\IRouter */
+	/** @var Nette\Routing\Router */
 	private $router;
 
 	/** @var Nette\Http\IRequest */
@@ -54,7 +54,7 @@ final class RoutingPanel implements Tracy\IBarPanel
 	}
 
 
-	public function __construct(Nette\Application\IRouter $router, Nette\Http\IRequest $httpRequest, Nette\Application\IPresenterFactory $presenterFactory)
+	public function __construct(Nette\Routing\Router $router, Nette\Http\IRequest $httpRequest, Nette\Application\IPresenterFactory $presenterFactory)
 	{
 		$this->router = $router;
 		$this->httpRequest = $httpRequest;
@@ -95,7 +95,7 @@ final class RoutingPanel implements Tracy\IBarPanel
 	/**
 	 * Analyses simple route.
 	 */
-	private function analyse(Nette\Application\IRouter $router, string $module = ''): void
+	private function analyse(Nette\Routing\Router $router, string $module = ''): void
 	{
 		if ($router instanceof Routers\RouteList) {
 			foreach ($router as $subRouter) {

--- a/tests/Application/Application.run.phpt
+++ b/tests/Application/Application.run.phpt
@@ -7,10 +7,10 @@ use Nette\Application\ApplicationException;
 use Nette\Application\BadRequestException;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\IResponse;
-use Nette\Application\IRouter;
 use Nette\Application\Request;
 use Nette\Application\Responses\ForwardResponse;
 use Nette\Application\Responses\TextResponse;
+use Nette\Routing\Router;
 use Tester\Assert;
 
 
@@ -79,7 +79,7 @@ $httpResponse->shouldIgnoreMissing();
 // no route without error presenter
 Assert::exception(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(null);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -94,7 +94,7 @@ test(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Error')->andReturn($errorPresenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(null);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -120,7 +120,7 @@ test(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Error')->andReturn($errorPresenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Error']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -146,7 +146,7 @@ Assert::exception(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Missing')->andThrow(Nette\Application\InvalidPresenterException::class);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Missing']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -162,7 +162,7 @@ test(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory->shouldReceive('createPresenter')->with('Missing')->andThrow(Nette\Application\InvalidPresenterException::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Error')->andReturn($errorPresenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Missing']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -188,7 +188,7 @@ Assert::exception(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Bad')->andReturn(new BadPresenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Bad']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -204,7 +204,7 @@ test(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory->shouldReceive('createPresenter')->with('Bad')->andReturn(new BadPresenter);
 	$presenterFactory->shouldReceive('createPresenter')->with('Error')->andReturn($errorPresenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Bad']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -232,7 +232,7 @@ Assert::noError(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Good')->andReturn($presenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Good']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -256,7 +256,7 @@ Assert::noError(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory->shouldReceive('createPresenter')->with('Good')->andReturn($presenter);
 	$presenterFactory->shouldReceive('createPresenter')->with('Error')->andReturn($errorPresenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Good']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);
@@ -281,7 +281,7 @@ Assert::noError(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Error')->andReturn($presenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 
 	$errors = [];
 
@@ -315,7 +315,7 @@ Assert::noError(function () use ($httpRequest, $httpResponse) {
 	$presenterFactory = Mockery::mock(IPresenterFactory::class);
 	$presenterFactory->shouldReceive('createPresenter')->with('Infinity')->andReturn($presenter);
 
-	$router = Mockery::mock(IRouter::class);
+	$router = Mockery::mock(Router::class);
 	$router->shouldReceive('match')->andReturn(['presenter' => 'Infinity']);
 
 	$app = new Application($presenterFactory, $router, $httpRequest, $httpResponse);

--- a/tests/Bridges.DI/RoutingExtension.cache.phpt
+++ b/tests/Bridges.DI/RoutingExtension.cache.phpt
@@ -15,7 +15,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-class MyRouter implements Nette\Application\IRouter
+class MyRouter implements Nette\Routing\Router
 {
 	public $woken;
 
@@ -78,7 +78,7 @@ test(function () {
 
 Assert::exception(function () {
 
-	/** @return Nette\Application\IRouter */
+	/** @return Nette\Routing\Router */
 	function myRouterFactory()
 	{
 		return new Route('path', function () {});

--- a/tests/Routers/Route.php
+++ b/tests/Routers/Route.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 use Tester\Assert;
 
 
-function testRouteIn(Nette\Application\IRouter $route, string $url, array $expectedParams = null, string $expectedUrl = null): void
+function testRouteIn(Nette\Routing\Router $route, string $url, array $expectedParams = null, string $expectedUrl = null): void
 {
 	$urlBuilder = new Nette\Http\Url("http://example.com$url");
 	$urlBuilder->appendQuery([
@@ -38,7 +38,7 @@ function testRouteIn(Nette\Application\IRouter $route, string $url, array $expec
 }
 
 
-function testRouteOut(Nette\Application\IRouter $route, array $params = []): ?string
+function testRouteOut(Nette\Routing\Router $route, array $params = []): ?string
 {
 	$url = new Nette\Http\UrlScript('http://example.com');
 	return $route->constructUrl($params, $url);

--- a/tests/Routers/RouteList.addRoute.phpt
+++ b/tests/Routers/RouteList.addRoute.phpt
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Application\Routers\RouteList;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Route.php';
+
+
+$list = new RouteList;
+$list->addRoute('foo', ['presenter' => 'foo'], RouteList::ONE_WAY);
+$list->addRoute('bar', ['presenter' => 'bar'], RouteList::ONE_WAY);
+$list->addRoute('hello', ['presenter' => 'hello']);
+
+
+testRouteIn($list, '/foo', ['presenter' => 'foo', 'test' => 'testvalue']);
+
+testRouteIn($list, '/bar', ['presenter' => 'bar', 'test' => 'testvalue']);
+
+testRouteIn($list, '/hello',
+	['presenter' => 'hello', 'test' => 'testvalue'],
+	'/hello?test=testvalue'
+);
+
+testRouteIn($list, '/none');

--- a/tests/Routers/RouteList.withModule.phpt
+++ b/tests/Routers/RouteList.withModule.phpt
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Application\Routers\RouteList;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Route.php';
+
+
+$list = new RouteList;
+$list
+	->withModule('A')
+		->addRoute('foo', ['presenter' => 'foo'])
+		->withModule('B')
+			->addRoute('bar', ['presenter' => 'bar'])
+		->end()
+	->end()
+	->withModule('C')
+		->addRoute('hello', ['presenter' => 'hello']);
+
+
+testRouteIn($list, '/foo',
+	['presenter' => 'A:foo', 'test' => 'testvalue'],
+	'/foo?test=testvalue'
+);
+
+testRouteIn($list, '/bar',
+	['presenter' => 'A:B:bar', 'test' => 'testvalue'],
+	'/bar?test=testvalue'
+);
+
+testRouteIn($list, '/hello',
+	['presenter' => 'C:hello', 'test' => 'testvalue'],
+	'/hello?test=testvalue'
+);
+
+testRouteIn($list, '/none');


### PR DESCRIPTION
Routers in nette/routing are pure, without any reference to concepts such as presenter / action. So they can't have:

1) constructors like `Route('mask', 'Presenter:action')`, only `Route('mask', ['presenter' => 'Presenter', 'action' => 'action'])`
2) support for special parameter `module`

So there are descendants in nette/application, which add this functionality.

The problem is that there are two classes in Nette like `Nette\Routing\Route` and `Nette\Application\Routers\Route` (in a similar relationship like `Nette\Forms\Form` and `Nette\Application\UI\Form`), which is not good. That's why I take this as a concept, not something ready to merge.