### PR TITLE
Presenter::sendJson: restrict allowed types

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -579,7 +579,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 	/**
 	 * Sends JSON data to the output.
-	 * @param  bool|float|int|string|array|\JsonSerializable $data
+	 * @param  bool|float|int|string|array|\DateTimeInterface|\JsonSerializable $data
 	 * @throws Nette\Application\AbortException
 	 */
 	public function sendJson($data): void

--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -579,7 +579,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 	/**
 	 * Sends JSON data to the output.
-	 * @param  mixed  $data
+	 * @param  bool|float|int|string|array|\JsonSerializable $data
 	 * @throws Nette\Application\AbortException
 	 */
 	public function sendJson($data): void


### PR DESCRIPTION
- improvement
- BC break: no

Hi,
yesterday I went to really bad issue that I passed object to Presenter::sendJson, but the object does not implement JsonSerializable, so only `{}` was returned in response.
This PR tries to solve this issues by restricting allowed types for parameter $data. It is then better analysable by IDE/static analyzers.

Allowed types may not be all, maybe I forgot some type which is ok.

Mentioned issue:
https://3v4l.org/qHse4

Thanks for comments/merge.