### PR TITLE
Fix phpDoc of Component::redirect

### DIFF
--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -276,7 +276,8 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 
 	/**
 	 * Redirect to another presenter, action or signal.
-	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
+	 * @param  string|int  $code  [optional] HTTP error code (deprecated)
+	 * @param  string|array|mixed   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
 	 * @param  array|mixed  $args
 	 * @throws Nette\Application\AbortException
 	 */


### PR DESCRIPTION
- bug fix / new feature?   bugfix
- BC break? no

Parameter $code is deprecated and optional, but still present. The phpDoc should reflect what arguments really accepts.

