### PR TITLE
Presenter: added onRender event

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -51,6 +51,9 @@ abstract class Presenter extends Control implements Application\IPresenter
 	/** @var callable[]&(callable(Presenter $sender): void)[]; Occurs when the presenter is starting */
 	public $onStartup;
 
+	/** @var callable[]&(callable(Presenter $sender): void)[]; Occurs when the presenter is rendering after beforeRender */
+	public $onRender;
+
 	/** @var callable[]&(callable(Presenter $sender, IResponse $response): void)[]; Occurs when the presenter is shutting down */
 	public $onShutdown;
 
@@ -213,6 +216,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 			// RENDERING VIEW
 			$this->beforeRender();
+			$this->onRender($this);
 			// calls $this->render<View>()
 			$this->tryCall($this->formatRenderMethod($this->view), $this->params);
 			$this->afterRender();


### PR DESCRIPTION
Added new onRender event, right after beforeRender and before actual render happends (as put it before beforeRender and called it onRender is confusing)

- Type: new feature
- BC break: noe
- doc PR: none

If we want to use traits in project, and mainly in extensios, there should be easy way, how to push somethink into template, but only if template is used. We have onStartup and onShutdown methods, but they are not ideal for this, as onStartup is called even if no reder<action> is performed, so if i add somethink to template there, it will cost me time of template creation, that will never use if redirect is called.

We have beforeRender and afterRender, but that is only methods, so we can modify them with trait.

I suggest new onRender method, that is called right after beforeRender, before render happends (if we called it onBeforeRender, we can put it before beforeRender method, but for i belive onRender is self describe so everybody will understand that.