### PR TITLE
Changed redirect() docs to support correct use-case

### DIFF
--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -276,8 +276,8 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 
 	/**
 	 * Redirect to another presenter, action or signal.
-	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
-	 * @param  array|mixed  $args
+	 * @param  string   $code in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
+	 * @param  array|mixed  $destination
 	 * @throws Nette\Application\AbortException
 	 */
 	public function redirect($code, $destination = null, $args = []): void


### PR DESCRIPTION
Helpful for static analysis like with phpstan - calls with deprecated `int $code` get reported while calls with destination and arguments only are considered valid.

Current behavior unfortunatelly support only calls with int $code and every up-to-date application needs to ignore phpstan errors with pattern like this `'#^Parameter \#2 \$destination of method Nette\\Application\\UI\\Component\:\:redirect\(\) expects string\|null, array.+given\.$#'`