### PR TITLE
redirect() input parameters

### DIFF
--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -276,12 +276,13 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 
 	/**
 	 * Redirect to another presenter, action or signal.
-	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
-	 * @param  array  $args
+	 * @param  string   	$destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
+	 * @param  array|mixed  $args
 	 * @throws Nette\Application\AbortException
 	 */
-	public function redirect(string $destination, array $args = []): void
+	public function redirect(string $destination, $args = []): void
 	{
+		$args = is_array($args) ? $args : array_slice(func_get_args(), 1);
 		$presenter = $this->getPresenter();
 		$presenter->redirectUrl($presenter->createRequest($this, $destination, $args, 'redirect'), null);
 	}

--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -277,24 +277,13 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 	/**
 	 * Redirect to another presenter, action or signal.
 	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
-	 * @param  array|mixed  $args
+	 * @param  array  $args
 	 * @throws Nette\Application\AbortException
 	 */
-	public function redirect($code, $destination = null, $args = []): void
+	public function redirect(string $destination, array $args = []): void
 	{
-		if (is_numeric($code)) {
-			trigger_error(__METHOD__ . '() first parameter $code is deprecated; use redirectPermanent() for 301 redirect.', E_USER_DEPRECATED);
-			if (func_num_args() > 3 || !is_array($args)) {
-				$args = array_slice(func_get_args(), 2);
-			}
-		} elseif (!is_numeric($code)) { // first parameter is optional
-			$args = func_num_args() < 3 && is_array($destination) ? $destination : array_slice(func_get_args(), 1);
-			$destination = $code;
-			$code = null;
-		}
-
 		$presenter = $this->getPresenter();
-		$presenter->redirectUrl($presenter->createRequest($this, $destination, $args, 'redirect'), $code);
+		$presenter->redirectUrl($presenter->createRequest($this, $destination, $args, 'redirect'), null);
 	}
 
 

--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -276,7 +276,7 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 
 	/**
 	 * Redirect to another presenter, action or signal.
-	 * @param  string   	$destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
+	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
 	 * @param  array|mixed  $args
 	 * @throws Nette\Application\AbortException
 	 */

--- a/tests/UI/Component.redirect().phpt
+++ b/tests/UI/Component.redirect().phpt
@@ -67,22 +67,6 @@ test(function () use ($presenter) {
 
 
 test(function () use ($presenter) {
-	@$presenter->redirect(301, 'foo', ['arg' => 1]); // @ is deprecated
-	Assert::type(Nette\Application\Responses\RedirectResponse::class, $presenter->response);
-	Assert::same(301, $presenter->response->getCode());
-	Assert::same('http://localhost/?arg=1&action=foo&presenter=test', $presenter->response->getUrl());
-});
-
-
-test(function () use ($presenter) {
-	@$presenter->redirect(301, 'foo', 2); // @ is deprecated
-	Assert::type(Nette\Application\Responses\RedirectResponse::class, $presenter->response);
-	Assert::same(301, $presenter->response->getCode());
-	Assert::same('http://localhost/?val=2&action=foo&presenter=test', $presenter->response->getUrl());
-});
-
-
-test(function () use ($presenter) {
 	$presenter->redirectPermanent('foo', 2);
 	Assert::type(Nette\Application\Responses\RedirectResponse::class, $presenter->response);
 	Assert::same(301, $presenter->response->getCode());


### PR DESCRIPTION
Removed deprecated $code input parameter and changed annotations for redirect() method

Fix for:
https://github.com/nette/application/issues/220