### PR TITLE
RoutingPanel: Add better panel responsivity

### DIFF
--- a/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
+++ b/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
@@ -47,7 +47,7 @@ use Tracy\Helpers;
 	<p>No routers defined.</p>
 
 <?php else: ?>
-	<table>
+	<table style="width: 100%">
 	<thead>
 	<tr>
 		<th></th>
@@ -61,9 +61,9 @@ use Tracy\Helpers;
 	<tbody>
 	<?php foreach ($routers as $router): ?>
 	<tr class="<?= $router['matched'] ?>">
-		<td><?= $router['matched'] === 'yes' ? '✓' : ($router['matched'] === 'may' ? '≈' : '') ?></td>
+		<td style="width:20px"><?= $router['matched'] === 'yes' ? '✓' : ($router['matched'] === 'may' ? '≈' : '') ?></td>
 
-		<td><code title="<?= Helpers::escapeHtml($router['class']) ?>"><?= Helpers::escapeHtml($router['mask'] ?? $router['class']) ?></code></td>
+		<td><code title="<?= Helpers::escapeHtml($router['class']) ?>"><?= str_replace(['\\', '/'], ['<wbr>\\', '<wbr>/'], Helpers::escapeHtml($router['mask'] ?? $router['class'])) ?></code></td>
 
 		<td><code>
 		<?php foreach ($router['defaults'] as $key => $value): ?>
@@ -88,9 +88,10 @@ use Tracy\Helpers;
 	</tbody>
 	</table>
 <?php endif ?>
-
+</div>
+<div class="tracy-inner-container">
 	<p><code><?= Helpers::escapeHtml($method) ?></code>
-	<code><?= Helpers::escapeHtml($url->getBaseUrl()) ?><span class="nette-RoutingPanel-rel"><?= Helpers::escapeHtml($url->getRelativeUrl()) ?></span></code></p>
+	<code><?= Helpers::escapeHtml($url->getBaseUrl()) ?><wbr><span class="nette-RoutingPanel-rel"><?= str_replace(['&amp;', '?'], ['<wbr>&amp;', '<wbr>?'], Helpers::escapeHtml($url->getRelativeUrl())) ?></span></code></p>
 
 	<?php if ($source): ?>
 	<p><a href="<?= Helpers::escapeHtml(Tracy\Helpers::editorUri($source->getFileName(), $source->getStartLine())) ?>"><?= $source instanceof \ReflectionClass ? $source->getName() : $source->getDeclaringClass()->getName() . '::' . $source->getName() . '()' ?></a></p>


### PR DESCRIPTION
- new feature
- BC break? no

My suggestion for better responsivity in case of resize window. This feature is very helpful when you must resize Tracy panel in small notebook screen or on mobile phone in case of debug by frontend developer in company local network.

New features:

1. Main table with `width: 100 %` for better user experience.

<img width="1377" alt="Snímek obrazovky 2019-07-30 v 13 59 56" src="https://user-images.githubusercontent.com/4738758/62127431-50cd0300-b2d2-11e9-93f1-cec847ac9fcf.png">

2. In case of medium size wrap lines around slashes in `Mask / Class` by `<wbr>` and keep slash before string on each new lines.

<img width="798" alt="Snímek obrazovky 2019-07-30 v 14 00 49" src="https://user-images.githubusercontent.com/4738758/62127474-70642b80-b2d2-11e9-9961-fc41a3559255.png">

3. Wrap URL parameters or path or both:

<img width="684" alt="Snímek obrazovky 2019-07-30 v 14 02 10" src="https://user-images.githubusercontent.com/4738758/62127546-a0abca00-b2d2-11e9-8714-1e46e09564c8.png">

<img width="609" alt="Snímek obrazovky 2019-07-30 v 14 02 20" src="https://user-images.githubusercontent.com/4738758/62127557-a73a4180-b2d2-11e9-81e2-4b977641f7ad.png">

<img width="387" alt="Snímek obrazovky 2019-07-30 v 14 02 33" src="https://user-images.githubusercontent.com/4738758/62127562-ae614f80-b2d2-11e9-9efa-97bae7c3f792.png">

Thanks.