### PR TITLE
WIP: Add handling of result from action* and handle*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"mockery/mockery": "^1.0"
 	},
 	"conflict": {
+		"nette/bootstrap": "<3.0.1",
 		"nette/di": "<3.0-stable",
 		"nette/forms": "<3.0",
 		"nette/latte": "<3.0"

--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -22,7 +22,7 @@ use Nette;
  * @property-read Presenter $presenter
  * @property-read bool $linkCurrent
  */
-abstract class Component extends Nette\ComponentModel\Container implements ISignalReceiver, IStatePersistent, \ArrayAccess
+abstract class Component extends Nette\ComponentModel\Container implements ISignalReceiverWithResult, IStatePersistent, \ArrayAccess
 {
 	use Nette\ComponentModel\ArrayAccess;
 
@@ -250,7 +250,7 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 		$this->signalResult = $result;
 	}
 
-	protected function getSignalResult(): ?HandleResult
+	public function getSignalResult(): ?HandleResult
 	{
 		return $this->signalResult;
 	}

--- a/src/Application/UI/HandleResult.php
+++ b/src/Application/UI/HandleResult.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Application\UI;
+
+/**
+ * Wrapper class of a value and origin pair.
+ *
+ * Used for action and signal result handling.
+ *
+ * @package Nette\Application\UI
+ */
+class HandleResult
+{
+	/** @var mixed */
+	private $value;
+
+	/** @var string */
+	private $origin;
+
+	/**
+	 * HandleResult constructor.
+	 *
+	 * @param mixed $value
+	 * @param string $origin
+	 */
+	public function __construct($value, string $origin)
+	{
+		$this->value = $value;
+		$this->origin = $origin;
+	}
+
+	/** @return mixed */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	/** @return string */
+	public function getOrigin(): string
+	{
+		return $this->origin;
+	}
+
+}

--- a/src/Application/UI/ISignalReceiverWithResult.php
+++ b/src/Application/UI/ISignalReceiverWithResult.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Application\UI;
+
+interface ISignalReceiverWithResult extends ISignalReceiver
+{
+	public function getSignalResult(): ?HandleResult;
+}

--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -374,7 +374,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 		$component->signalReceived($this->signal);
 		$this->signal = null;
 
-        return $component->getSignalResult();
+        return $component instanceof ISignalReceiverWithResult ? $component->getSignalResult() : null;
 	}
 
 


### PR DESCRIPTION
- new feature
- BC break? possibly yes
  - if someone relies on Component::tryCall's bool return type, they are screwed, they are ok if they only check truthy/falsy value
- doc PR: nette/docs#???  no additions

This PR adds possibility to presenters action* methods and components handle* methods to directly return response.

If they return scalar/array value, it is wrapped into typical JsonResponse (this response creation could and probably should be done via an additional service so the functionality is not coupled in the Presenter.

Right now, this PR is more of an API proposal to reduce coupling of Component handlers dependency on their presenter. More verbose description can be found [on the forum](https://forum.nette.org/en/32437-response-returning-from-presenter).

As I said, I'm not entirely happy about storing the handle result in a property but it is about the best I could come up with while not changing public API of the system too much.

TODO:
 - [ ] Agree on usage
 - [ ] Add some kind of "ResponseFactory" which creates response based on given data, maybe something like https://github.com/Thoronir42/praxos/blob/develop/sources/backend/src/Api/Presentation/JsonResponseFactory.php (don't mind rest of the project, it's botched up team semestral project)
 - [ ] Add some tests
 - [ ] Update doc blocks of changed code