### PR TITLE
BadRequestException parent Exception expect Throwable

### DIFF
--- a/src/Application/exceptions.php
+++ b/src/Application/exceptions.php
@@ -46,7 +46,7 @@ class BadRequestException extends \Exception
 	protected $code = Http\IResponse::S404_NOT_FOUND;
 
 
-	public function __construct(string $message = '', int $httpCode = 0, \Exception $previous = null)
+	public function __construct(string $message = '', int $httpCode = 0, \Throwable $previous = null)
 	{
 		parent::__construct($message, $httpCode ?: $this->code, $previous);
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

https://www.php.net/manual/en/class.exception.php
```
public __construct ([ string $message = "" [, int $code = 0 [, Throwable $previous = NULL ]]] )
```

The third parameter can be only \Throwable