### PR TITLE
Presenter: added isModuleCurrent() [Closes #240]

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -188,6 +188,18 @@ abstract class Presenter extends Control implements Application\IPresenter
 	}
 
 
+	public function isModuleCurrent(string $moduleName): bool
+	{
+		if (!$moduleName) {
+			throw new Nette\InvalidArgumentException('Missing module name!');
+		}
+
+		$moduleName = trim($moduleName, ':') . ':';
+
+		return Nette\Utils\Strings::startsWith($this->getModule() . ':', $moduleName);
+	}
+
+
 	/********************* interface IPresenter ****************d*g**/
 
 

--- a/tests/UI/Presenter.isModuleCurrent().phpt
+++ b/tests/UI/Presenter.isModuleCurrent().phpt
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Test: Presenter::isModuleCurrent.
+ */
+
+declare(strict_types = 1);
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class TestPresenter extends \Nette\Application\UI\Presenter
+{
+}
+
+
+Assert::exception(
+	function (): void {
+		$presenter = new TestPresenter;
+		$presenter->isModuleCurrent('');
+	},
+	\Nette\InvalidArgumentException::class
+);
+
+
+test(function () {
+	$presenter = new TestPresenter;
+	$presenter->setParent(null, 'Test');
+
+	Assert::same('', $presenter->getModule());
+
+	Assert::false($presenter->isModuleCurrent('Test'));
+	Assert::false($presenter->isModuleCurrent(':Test'));
+});
+
+
+test(function () {
+	$presenter = new TestPresenter;
+	$presenter->setParent(null, 'First:Second:Third:Test');
+
+	Assert::same('First:Second:Third', $presenter->getModule());
+
+	Assert::false($presenter->isModuleCurrent('First:Second:Third:Test'));
+
+	Assert::true($presenter->isModuleCurrent('First:Second:Third'));
+	Assert::true($presenter->isModuleCurrent('First:Second'));
+	Assert::true($presenter->isModuleCurrent('First'));
+
+	Assert::true($presenter->isModuleCurrent(':First:Second:Third'));
+	Assert::true($presenter->isModuleCurrent(':First:Second'));
+	Assert::true($presenter->isModuleCurrent(':First'));
+
+	Assert::true($presenter->isModuleCurrent('First:Second:Third:'));
+	Assert::true($presenter->isModuleCurrent('First:Second:'));
+	Assert::true($presenter->isModuleCurrent('First:'));
+
+	Assert::true($presenter->isModuleCurrent(':First:Second:Third:'));
+	Assert::true($presenter->isModuleCurrent(':First:Second:'));
+	Assert::true($presenter->isModuleCurrent(':First:'));
+
+	Assert::false($presenter->isModuleCurrent('First:Second:Other'));
+	Assert::false($presenter->isModuleCurrent('First:Other'));
+	Assert::false($presenter->isModuleCurrent('First:Second:T'));
+	Assert::false($presenter->isModuleCurrent('First:S'));
+});


### PR DESCRIPTION
- new feature
@dg has already added `$presenter->getModule()` method, which is universal. I've added an alternative to `$presenter->isLinkCurrent()` for modules.

- doc PR: nette/docs#???  I'd send PR if accepted. I've checked current doc and send small PR (https://github.com/nette/docs/pull/790). I would propose to describe new behavior in same section.
