### PR TITLE
Control, Presenter::createTemplate() added parameter $class for custom creation of the Template

### DIFF
--- a/src/Application/UI/Control.php
+++ b/src/Application/UI/Control.php
@@ -51,10 +51,11 @@ abstract class Control extends Component implements IRenderable
 	}
 
 
-	protected function createTemplate(): ITemplate
+	protected function createTemplate(?string $class = null): ITemplate
 	{
+		$class = $class ?? self::formatTemplateClass();
 		$templateFactory = $this->templateFactory ?: $this->getPresenter()->getTemplateFactory();
-		return $templateFactory->createTemplate($this, self::formatTemplateClass());
+		return $templateFactory->createTemplate($this, $class);
 	}
 
 

--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -556,9 +556,10 @@ abstract class Presenter extends Control implements Application\IPresenter
 	}
 
 
-	protected function createTemplate(): ITemplate
+	protected function createTemplate(?string $class = null): ITemplate
 	{
-		return $this->getTemplateFactory()->createTemplate($this, self::formatTemplateClass());
+		$class = $class ?? self::formatTemplateClass();
+		return $this->getTemplateFactory()->createTemplate($this, $class);
 	}
 
 


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

Based on the discussion in https://forum.nette.org/en/32893-custom-template-class-for-presenter-and-control-experimental-feature#p207624, I added parameters to these methods. Is it ok like this?