### PR TITLE
RoutingPanel: Add support for render routes with exception.

### DIFF
--- a/src/Bridges/ApplicationLatte/Template.php
+++ b/src/Bridges/ApplicationLatte/Template.php
@@ -60,9 +60,11 @@ class Template implements Nette\Application\UI\ITemplate
 	/**
 	 * Renders template to string.
 	 * @param  can throw exceptions? (hidden parameter)
+	 * @deprecated
 	 */
 	public function __toString(): string
 	{
+		trigger_error(__METHOD__ . '() is deprecated, renderToString() instead.', E_USER_DEPRECATED);
 		try {
 			return $this->latte->renderToString($this->file, $this->getParameters());
 		} catch (\Throwable $e) {

--- a/src/Bridges/ApplicationTracy/RoutingPanel.php
+++ b/src/Bridges/ApplicationTracy/RoutingPanel.php
@@ -83,6 +83,7 @@ final class RoutingPanel implements Tracy\IBarPanel
 	{
 		return Nette\Utils\Helpers::capture(function () {
 			$matched = $this->matched;
+			$matchedSymbols = ['yes' => '✓', 'may' => '≈', 'error' => '&times;'];
 			$routers = $this->routers;
 			$source = $this->source;
 			$hasModule = (bool) array_filter($routers, function (\stdClass $rq): string { return $rq->module; });
@@ -99,7 +100,11 @@ final class RoutingPanel implements Tracy\IBarPanel
 	private function analyse(Routing\Router $router, string $module = '', bool $parentMatches = true, int $level = -1): void
 	{
 		if ($router instanceof Routing\RouteList) {
-			$parentMatches = $parentMatches && $router->match($this->httpRequest) !== null;
+			try {
+				$parentMatches = $parentMatches && $router->match($this->httpRequest) !== null;
+			} catch (\Throwable $e) {
+				$parentMatches = true;
+			}
 			$next = count($this->routers);
 			foreach ($router->getRouters() as $subRouter) {
 				$this->analyse($subRouter, $module . $router->getModule(), $parentMatches, $level + 1);
@@ -119,6 +124,7 @@ final class RoutingPanel implements Tracy\IBarPanel
 		try {
 			$params = $parentMatches ? $router->match($this->httpRequest) : null;
 		} catch (\Exception $e) {
+			$matched = 'error';
 		}
 		if ($params !== null) {
 			if ($module) {

--- a/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
+++ b/src/Bridges/ApplicationTracy/templates/RoutingPanel.panel.phtml
@@ -26,6 +26,19 @@ use Tracy\Helpers;
 		background: #C1D3FF !important;
 	}
 
+	#tracy-debug .nette-RoutingPanel .error td {
+		background: #ffd2c3 !important;
+	}
+
+	#tracy-debug .nette-RoutingPanel .error .symbol {
+		color: #bf0014 !important;
+		font-weight: bold;
+	}
+
+	#tracy-debug .nette-RoutingPanel td.symbol {
+		text-align: center;
+	}
+
 	#tracy-debug .nette-RoutingPanel td:first-child {
 		width: 20px;
 	}
@@ -73,7 +86,7 @@ use Tracy\Helpers;
 	<tbody>
 	<?php foreach ($routers as $router): ?>
 	<tr class="<?= $router->matched ?>" style="border-width: <?=($router->gutterTop ?? 0) * 3?>px 0 <?=($router->gutterBottom ?? 0) * 3?>px <?=$router->level * 6?>px">
-		<td><?= $router->matched === 'yes' ? '✓' : ($router->matched === 'may' ? '≈' : '') ?></td>
+		<td class="symbol"><?= $matchedSymbols[$router->matched] ?? '' ?></td>
 
 		<td><code title="<?= Helpers::escapeHtml($router->class) ?>"><?= isset($router->mask) ? str_replace(['/', '-'], ['<wbr>/', '<wbr>-'], Helpers::escapeHtml($router->mask)) : str_replace('\\', '<wbr>\\', Helpers::escapeHtml($router->class)) ?></code></td>
 


### PR DESCRIPTION
- new feature
- BC break? no

I think in case of some Custom router throws exception it can be rendered in Tracy panel.

Current behavior (with callstack):

<img width="1147" alt="Snímek obrazovky 2020-04-24 v 10 01 40" src="https://user-images.githubusercontent.com/4738758/80191016-6b3fcd00-8615-11ea-9841-78054eb77020.png">

New behavior (with marked route and `x` symbol):

<img width="949" alt="Snímek obrazovky 2020-04-24 v 10 22 29" src="https://user-images.githubusercontent.com/4738758/80191079-814d8d80-8615-11ea-86fe-8cba6085d075.png">

I think this is more better. :)

Thanks.