### PR TITLE
Component->getPresenter() return type

### DIFF
--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -35,6 +35,7 @@ abstract class Component extends Nette\ComponentModel\Container implements ISign
 
 	/**
 	 * Returns the presenter where this component belongs to.
+	 * @return Presenter
 	 */
 	public function getPresenter(): ?Presenter
 	{

--- a/src/Bridges/ApplicationLatte/Template.php
+++ b/src/Bridges/ApplicationLatte/Template.php
@@ -60,9 +60,11 @@ class Template implements Nette\Application\UI\ITemplate
 	/**
 	 * Renders template to string.
 	 * @param  can throw exceptions? (hidden parameter)
+	 * @deprecated
 	 */
 	public function __toString(): string
 	{
+		trigger_error(__METHOD__ . '() is deprecated, renderToString() instead.', E_USER_DEPRECATED);
 		try {
 			return $this->latte->renderToString($this->file, $this->getParameters());
 		} catch (\Throwable $e) {


### PR DESCRIPTION
Changed annotated method return type to match non-deprecated behavior to satisfy static analysis. It would complain anyway, if user added hidden parameter to return null.