### PR TITLE
Prevent TypeError

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -214,7 +214,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 			// autoload components
 			foreach ($this->globalParams as $id => $foo) {
-				$this->getComponent($id, false);
+				$this->getComponent((string) $id, false);
 			}
 
 			if ($this->autoCanonicalize) {


### PR DESCRIPTION
- bug fix 
- BC break? no

If someone constructs a URL that looks like `example.com/?1-foo=bar`, Nette crashes with this error:

> Argument 1 passed to Nette\ComponentModel\Container::getComponent() must be of the type string, int given, called in vendor/nette/application/src/Application/UI/Presenter.php on line 217