### PR TITLE
flashMessage: allow HtmlStringable as a message

### DIFF
--- a/src/Application/UI/Control.php
+++ b/src/Application/UI/Control.php
@@ -93,7 +93,7 @@ abstract class Control extends Component implements Renderable
 
 	/**
 	 * Saves the message to template, that can be displayed after redirect.
-	 * @param  string|\stdClass  $message
+	 * @param  string|\stdClass|Nette\HtmlStringable $message
 	 */
 	public function flashMessage($message, string $type = 'info'): \stdClass
 	{


### PR DESCRIPTION
- bug fix for #271
- BC break? no (fixes BC break)

This allows behaviour which was supported before phpdoc was added. (there used to be `mixed` type for this parameter)

cc @dakur