### PR TITLE
LatteExtension: changed UI\TemplateFactory type to ApplicationLatte\TemplateFactory

### DIFF
--- a/src/Bridges/ApplicationDI/LatteExtension.php
+++ b/src/Bridges/ApplicationDI/LatteExtension.php
@@ -70,7 +70,7 @@ final class LatteExtension extends Nette\DI\CompilerExtension
 		}
 
 		$builder->addDefinition($this->prefix('templateFactory'))
-			->setType(Nette\Application\UI\TemplateFactory::class)
+			->setType(ApplicationLatte\TemplateFactory::class)
 			->setFactory(ApplicationLatte\TemplateFactory::class)
 			->setArguments(['templateClass' => $config->templateClass]);
 

--- a/src/Bridges/ApplicationDI/LatteExtension.php
+++ b/src/Bridges/ApplicationDI/LatteExtension.php
@@ -70,7 +70,6 @@ final class LatteExtension extends Nette\DI\CompilerExtension
 		}
 
 		$builder->addDefinition($this->prefix('templateFactory'))
-			->setType(ApplicationLatte\TemplateFactory::class)
 			->setFactory(ApplicationLatte\TemplateFactory::class)
 			->setArguments(['templateClass' => $config->templateClass]);
 


### PR DESCRIPTION
Latte TemplateFactory have `createTemplate()` extended for `$class` parameter and more accurate return typehint, which are both frequently used. This allows `TemplateFactory` to be autowired by `ApplicationLatte\TemplateFactory` type and prevent users confusion (like [here](https://forum.nette.org/en/34214-how-to-use-callbacks-in-services) and [here](https://forum.nette.org/cs/34209-factory-problem-s-construct))

Also some hint explaining why autowiring does not work when user sees in its DIC that service of requested type is available could be super helpful, but I have no idea how complicated the implementation would be