### PR TITLE
LatteExtension: inject interface to be more compatible

### DIFF
--- a/src/Bridges/ApplicationDI/LatteExtension.php
+++ b/src/Bridges/ApplicationDI/LatteExtension.php
@@ -94,17 +94,19 @@ final class LatteExtension extends Nette\DI\CompilerExtension
 	}
 
 
-	public static function initLattePanel(ApplicationLatte\TemplateFactory $factory, Tracy\Bar $bar, bool $all = false)
+	public static function initLattePanel(Nette\Application\UI\TemplateFactory $factory, Tracy\Bar $bar, bool $all = false)
 	{
-		$factory->onCreate[] = function (ApplicationLatte\Template $template) use ($bar, $all) {
-			$control = $template->getLatte()->getProviders()['uiControl'] ?? null;
-			if ($all || $control instanceof Nette\Application\UI\Presenter) {
-				$bar->addPanel(new Latte\Bridges\Tracy\LattePanel(
-					$template->getLatte(),
-					$all && $control ? (new \ReflectionObject($control))->getShortName() : '',
-				));
-			}
-		};
+		if ($factory instanceof ApplicationLatte\TemplateFactory) {
+			$factory->onCreate[] = function (ApplicationLatte\Template $template) use ($bar, $all) {
+				$control = $template->getLatte()->getProviders()['uiControl'] ?? null;
+				if ($all || $control instanceof Nette\Application\UI\Presenter) {
+					$bar->addPanel(new Latte\Bridges\Tracy\LattePanel(
+						$template->getLatte(),
+						$all && $control ? (new \ReflectionObject($control))->getShortName() : '',
+					));
+				}
+			};
+		}
 	}
 
 


### PR DESCRIPTION
- bug fix #287
- BC break? no

I hit the #287 too. After Latte upgrade and with my own `UI\TemplateFactory` implementation in DI (with `ApplicationLatte\TemplateFactory` autowiring off) container buid fails.

I thik this fix will work but it's a pitty that one lost new great latte panel. So it is more or less hotfix. Maybe to find another way how to hook the panel to template, maybe via decorator, but I'm sure how to do it.