### PR TITLE
Add `@return never` to redirect methods

### DIFF
--- a/src/Application/UI/Component.php
+++ b/src/Application/UI/Component.php
@@ -304,6 +304,7 @@ abstract class Component extends Nette\ComponentModel\Container implements Signa
 	 * Redirect to another presenter, action or signal.
 	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
 	 * @param  mixed  ...$args
+	 * @return never
 	 * @throws Nette\Application\AbortException
 	 */
 	public function redirect(string $destination, ...$args): void
@@ -320,6 +321,7 @@ abstract class Component extends Nette\ComponentModel\Container implements Signa
 	 * Permanently redirects to presenter, action or signal.
 	 * @param  string   $destination in format "[//] [[[module:]presenter:]action | signal! | this] [#fragment]"
 	 * @param  mixed  ...$args
+	 * @return never
 	 * @throws Nette\Application\AbortException
 	 */
 	public function redirectPermanent(string $destination, ...$args): void


### PR DESCRIPTION
- bug fix / new feature?   no / not really
- BC break? no

Adds `@return never` to `Component::redirect()` and `Component::redirectPermanent()`, useful for static analysis and required when any method using either of those wants to use `never` as its return type declaration (`function foo(): never`).

`Presenter::redirectUrl()` already [uses it](https://github.com/nette/application/blob/25e61b0de03bdb75a79ce5c72badcd4d3d6c4f01/src/Application/UI/Presenter.php#L609), this PR "propagates" it further.

Thank you!