### PR TITLE
not correct path to TextResponse class

### DIFF
--- a/src/Application/UI/Presenter.php
+++ b/src/Application/UI/Presenter.php
@@ -452,7 +452,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 			}
 		}
 
-		$this->sendResponse(new Responses\TextResponse($template));
+		$this->sendResponse(new Nette\Application\Responses\TextResponse($template));
 	}
 
 


### PR DESCRIPTION
I get massage error that Class "Nette\Application\UI\Responses\TextResponse" not found.  only writing correct path to this class help to fix it

- bug fix / new feature?   bug fix
- BC break? yes/no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
