### PR TITLE
Latte bridge: add block rendering support

### DIFF
--- a/src/Bridges/ApplicationLatte/Template.php
+++ b/src/Bridges/ApplicationLatte/Template.php
@@ -36,20 +36,20 @@ class Template implements Nette\Application\UI\Template
 	/**
 	 * Renders template to output.
 	 */
-	public function render(?string $file = null, array $params = []): void
+	public function render(?string $file = null, array $params = [], bool $block = null): void
 	{
 		Nette\Utils\Arrays::toObject($params, $this);
-		$this->latte->render($file ?: $this->file, $this);
+		$this->latte->render($file ?: $this->file, $this, $block);
 	}
 
 
 	/**
 	 * Renders template to output.
 	 */
-	public function renderToString(?string $file = null, array $params = []): string
+	public function renderToString(?string $file = null, array $params = [], bool $block = null): string
 	{
 		Nette\Utils\Arrays::toObject($params, $this);
-		return $this->latte->renderToString($file ?: $this->file, $this);
+		return $this->latte->renderToString($file ?: $this->file, $this, $block);
 	}
 
 


### PR DESCRIPTION
- new feature
- BC break: no
- doc PR: n/a

This pull request is adding missing support of the third parameter ($block) to render and renderToString methods of Nette Latte bridge. The $block parameter can be used to render a specific block of Latte template.

Related nette/latte issue: https://github.com/nette/latte/issues/101
Related nette/latte commit: https://github.com/nette/latte/commit/56e45145ec37e95d083e176e389bf2fcce0fcc15