### PR TITLE
allow Multiplier::createComponent() to return a null

### DIFF
--- a/src/Application/UI/Multiplier.php
+++ b/src/Application/UI/Multiplier.php
@@ -27,7 +27,7 @@ final class Multiplier extends Component
 	}
 
 
-	protected function createComponent(string $name): Nette\ComponentModel\IComponent
+	protected function createComponent(string $name): ?Nette\ComponentModel\IComponent
 	{
 		return ($this->factory)($name, $this);
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

We used this functionality in Nette 2.4; now it is still allowed in Container::createComponent().