### PR TITLE
Missing link from RoutingPanel.php to presenter class file in IDE

### DIFF
--- a/src/Bridges/ApplicationTracy/RoutingPanel.php
+++ b/src/Bridges/ApplicationTracy/RoutingPanel.php
@@ -134,7 +134,10 @@ final class RoutingPanel implements Tracy\IBarPanel
 			if (isset($params[Presenter::SignalKey])) {
 				return $rc->getSignalMethod($params[Presenter::SignalKey]);
 			} elseif (isset($params[Presenter::ActionKey])) {
-				return $rc->getActionRenderMethod($params[Presenter::ActionKey]);
+				$method = $rc->getActionRenderMethod($params[Presenter::ActionKey]);
+				if($method){
+					return $method;
+				}
 			}
 		}
 


### PR DESCRIPTION
RoutingPanel displays name of current presenter with current action method and link to presenter class file in IDE. In case that method of current presenter doesnt exists - this link is missing. Proposed change of code fixes this small bug.

- bug fix YES
- BC break? NO
- doc detailed description on nette forum: https://forum.nette.org/cs/36505-poopravit-proklik-z-routingpanelu-do-souboru-presenteru-v-ide#p226916

