### PR TITLE
Unify typehints of parameter $name in methods addFilter()

### DIFF
--- a/src/Bridges/ApplicationDI/ApplicationExtension.php
+++ b/src/Bridges/ApplicationDI/ApplicationExtension.php
@@ -111,7 +111,7 @@ final class ApplicationExtension extends Nette\DI\CompilerExtension
 
 		$builder->addDefinition($this->prefix('linkGenerator'))
 			->setFactory(Nette\Application\LinkGenerator::class, [
-				1 => new Definitions\Statement([new Definitions\Statement('@Nette\Http\IRequest::getUrl'), 'withoutUserInfo']),
+				1 => new Definitions\Statement([new Definitions\Statement('@Nette\Http\IRequest::getUrl'), 'withoutUserInfo()']),
 			]);
 
 		if ($this->name === 'application') {

--- a/src/Bridges/ApplicationLatte/Template.php
+++ b/src/Bridges/ApplicationLatte/Template.php
@@ -72,7 +72,7 @@ class Template implements Nette\Application\UI\Template
 	/**
 	 * Registers run-time filter.
 	 */
-	public function addFilter(?string $name, callable $callback): static
+	public function addFilter(string $name, callable $callback): static
 	{
 		$this->latte->addFilter($name, $callback);
 		return $this;


### PR DESCRIPTION
On nette forum in this post: https://forum.nette.org/cs/36685-latte-addfilter-neni-tam-chyba#p227757 was reported error - mismatch between typehints of parameter $name in methods addFilter() in Nette\Bridges\ApplicationLatte\Template and Latte\Engine, the correct typehint is defined by typehint of second parameter of php function preg_match() which is string. Consequently the correct typehint of parameter $name in method Nette\Bridges\ApplicationLatte\Template::addFilter() is pure string not nullable string

- bug fix 
- BC break - theoretically yes, but any use of null parameter $name leads to exception so fixing the bug makes anybody no harm
- post on nette forum:  https://forum.nette.org/cs/36685-latte-addfilter-neni-tam-chyba#p227757

