### PR TITLE
Add attribute #[AllowDynamicProperties]

### DIFF
--- a/src/Bridges/ApplicationLatte/Template.php
+++ b/src/Bridges/ApplicationLatte/Template.php
@@ -11,11 +11,12 @@ namespace Nette\Bridges\ApplicationLatte;
 
 use Latte;
 use Nette;
-
+use AllowDynamicProperties;
 
 /**
  * Latte powered template.
  */
+#[AllowDynamicProperties]
 class Template implements Nette\Application\UI\Template
 {
 	private ?string $file = null;


### PR DESCRIPTION
With coming soon PHP 8.4 it would be required for creating dynamic properties in class use of attribute #[AllowDynamicProperties]. The class Template is used as abstract class for typed latte templates and creating dynamic properties is  basic function of the class

new feature
- BC break - no



