### PR TITLE
Cast "true"/"false" to bool

### DIFF
--- a/src/Application/UI/ParameterConverter.php
+++ b/src/Application/UI/ParameterConverter.php
@@ -160,6 +160,16 @@ final class ParameterConverter
 			return false;
 		}
 
+		if ($type === 'bool') {
+			if ($val === 'true') {
+				$val = true;
+				return true;
+			} elseif ($val === 'false') {
+				$val = false;
+				return true;
+			}
+		}
+
 		$tmp = ($val === false ? '0' : (string) $val);
 		if ($type === 'float') {
 			$tmp = preg_replace('#\.0*$#D', '', $tmp);


### PR DESCRIPTION
- new feature
- BC break: no
- doc PR: probably not needed

For API routes/actions, It's really useful to cast "true" / "false" values to boolean and thus allow them to use for boolean parameters, because many other languages cast boolean to true/false and not 0/1 and then you are getting these "true"/"false" arguments.