### PR TITLE
Invalid @method annotation in DefaultTemplate

### DIFF
--- a/src/Application/MicroPresenter.php
+++ b/src/Application/MicroPresenter.php
@@ -124,8 +124,8 @@ final class MicroPresenter implements Application\IPresenter
 		$template->context = $this->context;
 		if ($this->httpRequest) {
 			$url = $this->httpRequest->getUrl();
-			$template->baseUrl = rtrim($url->getBaseUrl(), '/');
-			$template->basePath = rtrim($url->getBasePath(), '/');
+			$template->baseUrl = $url->getBaseUrl();
+			$template->basePath = $url->getBasePath();
 		}
 
 		return $template;

--- a/src/Bridges/ApplicationLatte/DefaultTemplate.php
+++ b/src/Bridges/ApplicationLatte/DefaultTemplate.php
@@ -14,9 +14,6 @@ use Nette;
 
 /**
  * Default template for controls and presenters.
- *
- * @method bool isLinkCurrent(string $destination = null, ...$args)
- * @method bool isModuleCurrent(string $module)
  */
 #[\AllowDynamicProperties]
 final class DefaultTemplate extends Template

--- a/src/Bridges/ApplicationLatte/TemplateFactory.php
+++ b/src/Bridges/ApplicationLatte/TemplateFactory.php
@@ -49,17 +49,15 @@ class TemplateFactory implements UI\TemplateFactory
 		$presenter = $control?->getPresenterIfExists();
 
 		// default parameters
-		$baseUrl = $this->httpRequest
-			? rtrim($this->httpRequest->getUrl()->withoutUserInfo()->getBaseUrl(), '/')
-			: null;
+        $url = $this->httpRequest?->getUrl()->withoutUserInfo();
 		$flashes = $presenter instanceof UI\Presenter && $presenter->hasFlashSession()
 			? (array) $presenter->getFlashSession()->get($control->getParameterId('flash'))
 			: [];
 
 		$params = [
 			'user' => $this->user,
-			'baseUrl' => $baseUrl,
-			'basePath' => $baseUrl ? preg_replace('#https?://[^/]+#A', '', $baseUrl) : null,
+            'baseUrl' => $url?->getBaseUrl(),
+            'basePath' => $url?->getBasePath(),
 			'flashes' => $flashes,
 			'control' => $control,
 			'presenter' => $presenter,


### PR DESCRIPTION
No BC break

I propose remove @method annotation of two non-existing methods you can't even call magically. IDE makes false suggestion in presenter when used type annotation DefaultTemplate for magic property $template:

```php
/**
 * @property DefaultTemplate $template
 */
final class MyPresenter extends BasePresenter
{
    public function actionDefault(): void
    {
        $isLinkCurrent = $this->template->isLinkCurrent(':Common:Sign:login');
    }
}
```

This code makes error:

```text
Error
Call to undefined method Nette\Bridges\ApplicationLatte\DefaultTemplate::isLinkCurrent()
```

It looks like the annotations have no function at all.
