### PR TITLE
SnippetRuntime: Fixed snippets rendering when multiple templates are rendered

### DIFF
--- a/src/Bridges/ApplicationLatte/SnippetRuntime.php
+++ b/src/Bridges/ApplicationLatte/SnippetRuntime.php
@@ -118,6 +118,8 @@ final class SnippetRuntime
 
 		$this->control->snippetMode = true;
 		$this->renderChildren();
+
+		$this->renderingSnippets = false;
 		return true;
 	}
 


### PR DESCRIPTION
I have component (BasketControl) with multiple templates. At nette 2.4 I was able to redraw snippets at all templates, but it is not working after upgrade to current version.

Example code:

public function handleAddProduct() {
	...
	$this->presenter['basketControl']->redrawControl('basketMessages');
	$this->presenter['basketControl']->snippetMode = true;
	$this->presenter['basketControl']->renderMessage();
	$this->presenter['basketControl']->redrawControl('small');
	$this->presenter['basketControl']->snippetMode = true;
	$this->presenter['basketControl']->renderSmall();
	$this->presenter->sendPayload();
}
Before this patch it ends with error - Possible problem: you are sending a HTTP header while already having some data in output buffer.

Is there some reason why it is not unsetted after snippetRendering? I have used this quick fix, but I'm not sure about consequences...