### PR TITLE
Refactor Application to return Response from processRequest

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -74,7 +74,7 @@ class Application
 	{
 		try {
 			Arrays::invoke($this->onStartup, $this);
-			$this->processRequest($this->createInitialRequest());
+			$this->processRequest($this->createInitialRequest())->send($this->httpRequest, $this->httpResponse);
 			Arrays::invoke($this->onShutdown, $this);
 
 		} catch (\Throwable $e) {
@@ -82,7 +82,7 @@ class Application
 			Arrays::invoke($this->onError, $this, $e);
 			if ($this->catchExceptions && ($req = $this->createErrorRequest($e))) {
 				try {
-					$this->processRequest($req);
+					$this->processRequest($req)->send($this->httpRequest, $this->httpResponse);
 					Arrays::invoke($this->onShutdown, $this, $e);
 					return;
 
@@ -121,7 +121,7 @@ class Application
 	}
 
 
-	public function processRequest(Request $request): void
+	public function processRequest(Request $request): Response
 	{
 		process:
 		if (count($this->requests) > $this->maxLoop) {
@@ -156,7 +156,7 @@ class Application
 		}
 
 		Arrays::invoke($this->onResponse, $this, $response);
-		$response->send($this->httpRequest, $this->httpResponse);
+		return $response;
 	}
 
 


### PR DESCRIPTION
- bug fix / new feature?
  refactor
- BC break?
  yes
- doc PR: nette/docs
  not yet, i will add it when i know this PR can be merged

Changed Application::processRequest to return a Response object instead of sending it directly. Updated run() to call send() on the returned Response. This improves testability and separation of concerns by decoupling request processing from response sending.

This is code regarding my issue #348, this would really help us create long-running application, as with simple change we can run processRequest and get response for PSR response, all other stuff can be done, but without this, we are forced to do ob_cache and it is not nice solution :)