### PR TITLE
LinkGenerator: do not pass defaults of #[Parameter]

### DIFF
--- a/src/Application/LinkGenerator.php
+++ b/src/Application/LinkGenerator.php
@@ -170,6 +170,12 @@ final class LinkGenerator
 				trigger_error("Link to deprecated presenter '$presenter' from '{$refPresenter->getName()}:{$refPresenter->getAction()}'.", E_USER_DEPRECATED);
 			}
 
+			foreach (array_intersect_key($reflection->getParameters(), $args) as $name => $param) {
+				if ($args[$name] === $param['def']) {
+					$args[$name] = null; // value transmit is unnecessary
+				}
+			}
+
 			// counterpart of run() & tryCall()
 			if ($method = $reflection->getActionRenderMethod($action)) {
 				if ($this->isDeprecated($refPresenter, $method)) {

--- a/src/Application/UI/ComponentReflection.php
+++ b/src/Application/UI/ComponentReflection.php
@@ -55,6 +55,7 @@ final class ComponentReflection extends \ReflectionClass
 				];
 			} elseif ($prop->getAttributes(Attributes\Parameter::class)) {
 				$params[$prop->getName()] = [
+					'def' => $prop->getDefaultValue(),
 					'type' => (string) ($prop->getType() ?? 'mixed'),
 				];
 			}

--- a/tests/UI/ComponentReflection.getParameters().phpt
+++ b/tests/UI/ComponentReflection.getParameters().phpt
@@ -51,6 +51,7 @@ Assert::same(
 			'since' => 'OnePresenter',
 		],
 		'yes3' => [
+			'def' => null,
 			'type' => 'mixed',
 		],
 	],
@@ -60,9 +61,11 @@ Assert::same(
 Assert::same(
 	[
 		'yes2' => [
+			'def' => null,
 			'type' => 'mixed',
 		],
 		'yes4' => [
+			'def' => null,
 			'type' => 'mixed',
 		],
 		'yes1' => [
@@ -71,6 +74,7 @@ Assert::same(
 			'since' => 'OnePresenter',
 		],
 		'yes3' => [
+			'def' => null,
 			'type' => 'mixed',
 		],
 	],


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: n/a

With `render($x = 1)`, no URL parameter is added when linking to `x => 1`. With `#[Parameter] public $x = 1`, it was added. This PR fixes it.