### PR TITLE
LinkGenerator: allow 'test' mode in link target validation

### DIFF
--- a/src/Application/LinkGenerator.php
+++ b/src/Application/LinkGenerator.php
@@ -12,7 +12,7 @@ namespace Nette\Application;
 use Nette\Http\UrlScript;
 use Nette\Routing\Router;
 use Nette\Utils\Reflection;
-use function array_intersect_key, array_key_exists, http_build_query, is_string, is_subclass_of, parse_str, preg_match, rtrim, str_contains, str_ends_with, strcasecmp, strlen, strncmp, strtr, substr, trigger_error, urldecode;
+use function array_intersect_key, array_key_exists, http_build_query, in_array, is_string, is_subclass_of, parse_str, preg_match, rtrim, str_contains, str_ends_with, strcasecmp, strlen, strncmp, strtr, substr, trigger_error, urldecode;
 
 
 /**
@@ -299,7 +299,7 @@ final class LinkGenerator
 		string $mode,
 	): void
 	{
-		if ($mode !== 'forward' && !(new UI\AccessPolicy($element))->isLinkable()) {
+		if (!in_array($mode, ['test', 'forward']) && !(new UI\AccessPolicy($element))->isLinkable()) {
 			throw new UI\InvalidLinkException("Link to forbidden $message from '{$presenter->getName()}:{$presenter->getAction()}'.");
 		} elseif ($presenter?->invalidLinkMode
 			&& (UI\ComponentReflection::parseAnnotation($element, 'deprecated') || $element->getAttributes(Attributes\Deprecated::class))

--- a/src/Application/LinkGenerator.php
+++ b/src/Application/LinkGenerator.php
@@ -299,7 +299,7 @@ final class LinkGenerator
 		string $mode,
 	): void
 	{
-		if (!in_array($mode, ['test', 'forward']) && !(new UI\AccessPolicy($element))->isLinkable()) {
+		if (!in_array($mode, ['test', 'forward'], true) && !(new UI\AccessPolicy($element))->isLinkable()) {
 			throw new UI\InvalidLinkException("Link to forbidden $message from '{$presenter->getName()}:{$presenter->getAction()}'.");
 		} elseif ($presenter?->invalidLinkMode
 			&& (UI\ComponentReflection::parseAnnotation($element, 'deprecated') || $element->getAttributes(Attributes\Deprecated::class))


### PR DESCRIPTION
The change allows the use/validation of 'test' mode over presenters containing the Requires attribute (e.g., using the isLinkCurrent method on the Error4xx presenter).

This is reaction to this [commit](https://github.com/nette/application/commit/1b0aa5529a72f588ef7415b06d7542108ed03f8e). 

- bug fix
- BC break? no
